### PR TITLE
Fetch statsgo

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,4 +1,5 @@
 source("1_fetch/src/download_nhdplus_flowlines.R")
+source('1_fetch/src/sb_read_filter_by_comids.R')
 
 p1_targets_list <- list(
   
@@ -68,7 +69,7 @@ p1_targets_list <- list(
     lapply(p1_selected_statsgo_sbid_children,
            function(x){sbtools::item_file_download(x$id,
                                                    dest_dir = '1_fetch/out/statsgo',
-                                                   overwrite_file = TRUE)}
+                                                   overwrite_file = FALSE)}
            ) %>%
       unlist(),
     format = 'file'

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -48,23 +48,29 @@ p1_targets_list <- list(
     download_nhdplus_flowlines(p1_drb_comids_all_tribs$COMID)
   ),
   
-  # get nhdv2 STATSGO Soil Characteristics
-  
+  # STATSGO SOIL Characteristics
+  ## get selected child items nhdv2 STATSGO Soil Characteristics
+  ## 1) Text attributes and 2) Layer attributes
   tar_target(
     selected_statsgo_sbid_children,
     item_list_children(sb_id = nhd_statsgo_parent_sbid) %>% 
       Filter(function(x){str_detect(x[['title']],'Text|Layer')},
              .)
     ),
-
+  
+  ## download selected CONUS STATSGO datasets from Science base
   tar_target(
     download_statsgo_text_layer_attr,
     lapply(selected_statsgo_sbid_children,
            function(x){sbtools::item_file_download(x$id,
-                                                   dest_dir = '1_fetch/out/statsgo')}
-           ),
+                                                   dest_dir = '1_fetch/out/statsgo',
+                                                   overwrite_file = TRUE)}
+           ) %>%
+      unlist(),
     format = 'file'
     )
+  
+  ## Combine statsgo TEXT and Layer Attributes for CAT and TOT and filter to drb
 )
   
 

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -37,10 +37,6 @@ p1_targets_list <- list(
       rename(COMID = comid_cat)
   ),
   
-  ## define drb comids vector
-  tar_target(comids_drb,
-             p1_drb_comids_all_tribs$COMID),
-  
   # Use crosswalk table to fetch just the NHDv2 reaches that overlap the NHM network
   tar_target(
     p1_nhd_reaches_along_NHM,

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -77,12 +77,13 @@ p1_targets_list <- list(
   
   ## Combine statsgo TEXT and Layer Attributes for CAT and TOT and filter to drb
   tar_target(
-    p1_statsgo_soil_df, 
+    p1_statsgo_soil_df,
     sb_read_filter_by_comids(data_path = '1_fetch/out/statsgo',
                              comid = p1_drb_comids_all_tribs$COMID,
                              sb_comid_col = 'COMID',
                              selected_cols_contains = c("KFACT","KFACT_UP","NO10AVE",
-                                                        "NO4AVE","SILTAVE","CLAYAVE","SANDAVE"),
+                                                        "NO4AVE","SILTAVE","CLAYAVE",
+                                                        "SANDAVE",'WTDEP'),
                              cbind = TRUE)
   )
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -36,6 +36,10 @@ p1_targets_list <- list(
       rename(COMID = comid_cat)
   ),
   
+  ## define drb comids vector
+  tar_target(comids_drb,
+             p1_drb_comids_all_tribs$COMID),
+  
   # Use crosswalk table to fetch just the NHDv2 reaches that overlap the NHM network
   tar_target(
     p1_nhd_reaches_along_NHM,
@@ -52,7 +56,7 @@ p1_targets_list <- list(
   ## get selected child items nhdv2 STATSGO Soil Characteristics
   ## 1) Text attributes and 2) Layer attributes
   tar_target(
-    selected_statsgo_sbid_children,
+    p1_selected_statsgo_sbid_children,
     item_list_children(sb_id = nhd_statsgo_parent_sbid) %>% 
       Filter(function(x){str_detect(x[['title']],'Text|Layer')},
              .)
@@ -60,19 +64,24 @@ p1_targets_list <- list(
   
   ## download selected CONUS STATSGO datasets from Science base
   tar_target(
-    download_statsgo_text_layer_attr,
-    lapply(selected_statsgo_sbid_children,
+    p1_download_statsgo_text_layer_attr,
+    lapply(p1_selected_statsgo_sbid_children,
            function(x){sbtools::item_file_download(x$id,
                                                    dest_dir = '1_fetch/out/statsgo',
                                                    overwrite_file = TRUE)}
            ) %>%
       unlist(),
     format = 'file'
-    )
+    ),
   
   ## Combine statsgo TEXT and Layer Attributes for CAT and TOT and filter to drb
+  tar_target(
+    p1_statsgo_soil_df, 
+    sb_read_filter_by_comids(data_path = '1_fetch/out/statsgo',
+                             comid = p1_drb_comids_all_tribs$COMID,
+                             cbind = TRUE)
+  )
 )
   
-
 
   

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -54,7 +54,7 @@ p1_targets_list <- list(
   ## 1) Text attributes and 2) Layer attributes
   tar_target(
     p1_selected_statsgo_sbid_children,
-    item_list_children(sb_id = nhd_statsgo_parent_sbid) %>% 
+    sbtools::item_list_children(sb_id = nhd_statsgo_parent_sbid) %>% 
       Filter(function(x){str_detect(x[['title']],'Text|Layer')},
              .)
     ),

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,5 +1,6 @@
 source("1_fetch/src/download_nhdplus_flowlines.R")
 source('1_fetch/src/sb_read_filter_by_comids.R')
+source("1_fetch/src/download_sb_file.R")
 
 p1_targets_list <- list(
   
@@ -63,14 +64,14 @@ p1_targets_list <- list(
   tar_target(
     p1_download_statsgo_text_layer_zip,
     lapply(p1_selected_statsgo_sbid_children,
-           function(x){sbtools::item_file_download(x$id,
-                                                   dest_dir = '1_fetch/out/statsgo',
-                                                   overwrite_file = TRUE)}
+           function(x){download_sb_file(sb_id = x$id,
+                                        out_dir = '1_fetch/out/statsgo',
+                                        file_name = NULL,
+                                        overwrite_file = TRUE)}
            ) %>%
       unlist(),
-    format = 'file'
-    ),
-  
+    format = 'file'),
+
   ## Combine statsgo TEXT and Layer Attributes for CAT and TOT and filter to drb
   tar_target(
     p1_statsgo_soil_df,

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -81,9 +81,8 @@ p1_targets_list <- list(
     sb_read_filter_by_comids(data_path = '1_fetch/out/statsgo',
                              comid = p1_drb_comids_all_tribs$COMID,
                              sb_comid_col = 'COMID',
+                             selected_cols_contains = c("KFACT","KFACT_UP","NO10AVE",
+                                                        "NO4AVE","SILTAVE","CLAYAVE","SANDAVE"),
                              cbind = TRUE)
   )
 )
-  
-
-  

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -46,9 +46,27 @@ p1_targets_list <- list(
   tar_target(
     p1_nhd_reaches,
     download_nhdplus_flowlines(p1_drb_comids_all_tribs$COMID)
-  )
-
+  ),
   
+  # get nhdv2 STATSGO Soil Characteristics
+  
+  tar_target(
+    selected_statsgo_sbid_children,
+    item_list_children(sb_id = nhd_statsgo_parent_sbid) %>% 
+      Filter(function(x){str_detect(x[['title']],'Text|Layer')},
+             .)
+    ),
+
+  tar_target(
+    download_statsgo_text_layer_attr,
+    lapply(selected_statsgo_sbid_children,
+           function(x){sbtools::item_file_download(x$id,
+                                                   dest_dir = '1_fetch/out/statsgo')}
+           ),
+    format = 'file'
+    )
 )
+  
+
 
   

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -69,7 +69,7 @@ p1_targets_list <- list(
     lapply(p1_selected_statsgo_sbid_children,
            function(x){sbtools::item_file_download(x$id,
                                                    dest_dir = '1_fetch/out/statsgo',
-                                                   overwrite_file = FALSE)}
+                                                   overwrite_file = TRUE)}
            ) %>%
       unlist(),
     format = 'file'
@@ -80,6 +80,7 @@ p1_targets_list <- list(
     p1_statsgo_soil_df, 
     sb_read_filter_by_comids(data_path = '1_fetch/out/statsgo',
                              comid = p1_drb_comids_all_tribs$COMID,
+                             sb_comid_col = 'COMID',
                              cbind = TRUE)
   )
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -61,7 +61,7 @@ p1_targets_list <- list(
   
   ## download selected CONUS STATSGO datasets from Science base
   tar_target(
-    p1_download_statsgo_text_layer_attr,
+    p1_download_statsgo_text_layer_zip,
     lapply(p1_selected_statsgo_sbid_children,
            function(x){sbtools::item_file_download(x$id,
                                                    dest_dir = '1_fetch/out/statsgo',

--- a/1_fetch/src/download_sb_file.R
+++ b/1_fetch/src/download_sb_file.R
@@ -1,0 +1,27 @@
+download_sb_file <- function(sb_id, out_dir, file_name = NULL, overwrite_file = TRUE){
+  #'
+  #' @description Function to download file from ScienceBase 
+  #'
+  #' @param sb_id string - the id of the science base item
+  #' @param file_name string - the name of the file in the science base item to download
+  #' @param out_dir string - the directory where you want the file downloaded to
+  #'
+  #' @value string the out_path
+  
+  if(!is.null(file_name)){
+    
+    out_path = file.path(out_dir, file_name)
+    # Get the data from ScienceBase:
+    sbtools::item_file_download(sb_id = sb_id,
+                                names = file_name,
+                                destinations = out_path,
+                                overwrite_file = overwrite_file)
+  } else {
+    # Get the data from ScienceBase:
+    out_path <- sbtools::item_file_download(sb_id = sb_id,
+                                            dest_dir = out_dir, 
+                                            overwrite_file = overwrite_file)
+    }
+  
+  return(out_path)
+}

--- a/1_fetch/src/sb_read_filter_by_comids.R
+++ b/1_fetch/src/sb_read_filter_by_comids.R
@@ -1,26 +1,30 @@
 #' Function to filter sb datasets to given comids in AOI. Generates unzip if needed.  
 
-sb_read_filter_by_comids <- function(data_path = '1_fetch/out/statsgo', comid, cbind = TRUE){
+sb_read_filter_by_comids <- function(data_path = '1_fetch/out/statsgo', sb_comid_col = 'COMID', comid, cbind = TRUE){
   
   #' @param comid character string or vector of character strings containing
   #' the common identifier (COMID) of the desired flowline(s)
   #' @param data_path folder path to files downloaded from sb
   #' @param cbind if true read in files are merged by column COMID
   
-  ##unzip  
+  ##unzip - if no zip this will 
   data_zip_lst <- list.files(path = data_path, pattern = '*.zip', full.names = TRUE)
-  lapply(data_zip_lst, function(x) unzip(x, exdir = '1_fetch/out/statsgo',overwrite = FALSE))
   
-  ## identify unzipped files
+  if(!is_empty(data_zip_lst)){
+  ##unzipping in sale location as zipped. No subfolder created 
+  lapply(data_zip_lst, function(x) unzip(x, exdir = data_path))
+  }
+
+  ## Pull downloaded files
   data_lst <- list.files(path = data_path, pattern = '*.TXT|*.csv', full.names = TRUE)
   
   ## read in + clip
-  data <- lapply(data_lst, function(x) read.delim(x, sep = ',') %>% 
-                   filter(COMID %in% comid)
-                 )
+  data <- lapply(data_lst[1:4], function(x) read.delim(x, sep = ',') %>% 
+                   filter(.data[[sb_comid_col]] %in% comid))
+                 
   ## cbind if true
   if(cbind == TRUE){
-    full_df <- data %>% reduce(full_join, by = 'COMID')
+    full_df <- data %>% reduce(full_join, by = sb_comid_col)
   } else{full_df <- data}
   
   return(full_df)  

--- a/1_fetch/src/sb_read_filter_by_comids.R
+++ b/1_fetch/src/sb_read_filter_by_comids.R
@@ -1,10 +1,13 @@
 #' Function to filter sb datasets to given comids in AOI. Generates unzip if needed.  
 
-sb_read_filter_by_comids <- function(data_path = '1_fetch/out/statsgo', sb_comid_col = 'COMID', comid, cbind = TRUE){
+sb_read_filter_by_comids <- function(comid, data_path, sb_comid_col = 'COMID',
+                                     selected_cols_contains = NULL, cbind = TRUE){
   
-  #' @param comid character string or vector of character strings containing
-  #' the common identifier (COMID) of the desired flowline(s)
+  #' @description function to unzip, fetch and munge datasets from Sciencebase. Built for STATSGO but generalized for ther SB datasets
+  #' @param comid character string or vector of character strings containing the common identifier (COMID) of the desired flowline(s)
   #' @param data_path folder path to files downloaded from sb
+  #' @param sb_comid_col str of the the column name from the comids. Default is 'COMID' as this is typically the name of this column from ds from SB0
+  #' @param selected_cols_contains char vector of columns of interest from original dataset e.g. c('KFACT','KFACT_UP','NO10AVE','NO4AVE','SILTAVE','CLAYAVE','SANDAVE'). Do not include the comid id colname
   #' @param cbind if true read in files are merged by column COMID
   
   # 1) unzip - if no zip this will pass 
@@ -21,11 +24,17 @@ sb_read_filter_by_comids <- function(data_path = '1_fetch/out/statsgo', sb_comid
   if(is_empty(data_lst)){
     stop('No txt or csv file in this data path')
   }
+  
   ## read in + clip
   data <- lapply(data_lst, function(x) read.csv(x, sep = ',') %>% 
+                   ### selecting only specified columns of param selected_cols_contains
+                   {if(!is.null(selected_cols_contains))
+                     select(.,contains(append(sb_comid_col,
+                                              selected_cols_contains))) else .} %>% 
+                   ### filter to comid in AOI
                    filter(.data[[sb_comid_col]] %in% comid))
-                 
-  ## cbind if true
+  
+  # 3) cbind if true
   if(cbind == TRUE){
     full_df <- data %>% reduce(full_join, by = sb_comid_col)
   } else{full_df <- data}

--- a/1_fetch/src/sb_read_filter_by_comids.R
+++ b/1_fetch/src/sb_read_filter_by_comids.R
@@ -7,19 +7,22 @@ sb_read_filter_by_comids <- function(data_path = '1_fetch/out/statsgo', sb_comid
   #' @param data_path folder path to files downloaded from sb
   #' @param cbind if true read in files are merged by column COMID
   
-  ##unzip - if no zip this will 
+  # 1) unzip - if no zip this will pass 
   data_zip_lst <- list.files(path = data_path, pattern = '*.zip', full.names = TRUE)
   
   if(!is_empty(data_zip_lst)){
-  ##unzipping in sale location as zipped. No subfolder created 
+  ##unzipping in same location as zipped. No subfolder created 
   lapply(data_zip_lst, function(x) unzip(x, exdir = data_path))
   }
-
+  
+  # 2) read
   ## Pull downloaded files
   data_lst <- list.files(path = data_path, pattern = '*.TXT|*.csv', full.names = TRUE)
-  
+  if(is_empty(data_lst)){
+    stop('No txt or csv file in this data path')
+  }
   ## read in + clip
-  data <- lapply(data_lst[1:4], function(x) read.delim(x, sep = ',') %>% 
+  data <- lapply(data_lst[1:4], function(x) read.csv(x, sep = ',') %>% 
                    filter(.data[[sb_comid_col]] %in% comid))
                  
   ## cbind if true

--- a/1_fetch/src/sb_read_filter_by_comids.R
+++ b/1_fetch/src/sb_read_filter_by_comids.R
@@ -1,0 +1,27 @@
+#' Function to filter sb datasets to given comids in AOI. Generates unzip if needed.  
+
+sb_read_filter_by_comids <- function(data_path = '1_fetch/out/statsgo', comid, cbind = TRUE){
+  
+  #' @param comid character string or vector of character strings containing
+  #' the common identifier (COMID) of the desired flowline(s)
+  #' @param data_path folder path to files downloaded from sb
+  #' @param cbind if true read in files are merged by column COMID
+  
+  ##unzip  
+  data_zip_lst <- list.files(path = data_path, pattern = '*.zip', full.names = TRUE)
+  lapply(data_zip_lst, function(x) unzip(x, exdir = '1_fetch/out/statsgo',overwrite = FALSE))
+  
+  ## identify unzipped files
+  data_lst <- list.files(path = data_path, pattern = '*.TXT|*.csv', full.names = TRUE)
+  
+  ## read in + clip
+  data <- lapply(data_lst, function(x) read.delim(x, sep = ',') %>% 
+                   filter(COMID %in% comid)
+                 )
+  ## cbind if true
+  if(cbind == TRUE){
+    full_df <- data %>% reduce(full_join, by = 'COMID')
+  } else{full_df <- data}
+  
+  return(full_df)  
+} 

--- a/1_fetch/src/sb_read_filter_by_comids.R
+++ b/1_fetch/src/sb_read_filter_by_comids.R
@@ -6,7 +6,7 @@ sb_read_filter_by_comids <- function(comid, data_path, sb_comid_col = 'COMID',
   #' @description function to unzip, fetch and munge datasets from Sciencebase. Built for STATSGO but generalized for ther SB datasets
   #' @param comid character string or vector of character strings containing the common identifier (COMID) of the desired flowline(s)
   #' @param data_path folder path to files downloaded from sb
-  #' @param sb_comid_col str of the the column name from the comids. Default is 'COMID' as this is typically the name of this column from ds from SB0
+  #' @param sb_comid_col str of the the column name from the comids. Default is 'COMID' as this is typically the name of this column from ds from SB.
   #' @param selected_cols_contains char vector of columns of interest from original dataset e.g. c('KFACT','KFACT_UP','NO10AVE','NO4AVE','SILTAVE','CLAYAVE','SANDAVE'). Do not include the comid id colname
   #' @param cbind if true read in files are merged by column COMID
   

--- a/1_fetch/src/sb_read_filter_by_comids.R
+++ b/1_fetch/src/sb_read_filter_by_comids.R
@@ -12,7 +12,7 @@ sb_read_filter_by_comids <- function(data_path = '1_fetch/out/statsgo', sb_comid
   
   if(!is_empty(data_zip_lst)){
   ##unzipping in same location as zipped. No subfolder created 
-  lapply(data_zip_lst, function(x) unzip(x, exdir = data_path))
+  lapply(data_zip_lst, function(x) unzip(x, exdir = data_path, overwrite = TRUE))
   }
   
   # 2) read
@@ -22,7 +22,7 @@ sb_read_filter_by_comids <- function(data_path = '1_fetch/out/statsgo', sb_comid
     stop('No txt or csv file in this data path')
   }
   ## read in + clip
-  data <- lapply(data_lst[1:4], function(x) read.csv(x, sep = ',') %>% 
+  data <- lapply(data_lst, function(x) read.csv(x, sep = ',') %>% 
                    filter(.data[[sb_comid_col]] %in% comid))
                  
   ## cbind if true

--- a/_targets.R
+++ b/_targets.R
@@ -3,7 +3,20 @@ library(targets)
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse","sbtools","sf","nhdplusTools")) 
 
+# dir for selected datasets from nhd statsgo
+dir.create('1_fetch/out/statsgo', showWarnings = FALSE)
+
 source("1_fetch.R")
+
+# Define minor HUCs (hydrologic unit codes) that make up the DRB to use in calls to dataRetrieval functions
+# Lower Delaware: 0204 subregion (for now, exclude New Jersey Coastal (https://water.usgs.gov/GIS/huc_name.html)
+drb_huc8s <- c("02040101","02040102","02040103","02040104","02040105","02040106",
+               "02040201","02040202","02040203","02040204","02040205",
+               "02040206","02040207")
+
+## nhd parent id 
+# pulled from https://www.sciencebase.gov/catalog/item/5728d6ace4b0b13d3918a992
+nhd_statsgo_parent_sbid <- '5728d6ace4b0b13d3918a992'
 
 # Return the complete list of targets
 c(p1_targets_list)

--- a/_targets.R
+++ b/_targets.R
@@ -8,12 +8,6 @@ dir.create('1_fetch/out/statsgo', showWarnings = FALSE)
 
 source("1_fetch.R")
 
-# Define minor HUCs (hydrologic unit codes) that make up the DRB to use in calls to dataRetrieval functions
-# Lower Delaware: 0204 subregion (for now, exclude New Jersey Coastal (https://water.usgs.gov/GIS/huc_name.html)
-drb_huc8s <- c("02040101","02040102","02040103","02040104","02040105","02040106",
-               "02040201","02040202","02040203","02040204","02040205",
-               "02040206","02040207")
-
 ## nhd parent id 
 # pulled from https://www.sciencebase.gov/catalog/item/5728d6ace4b0b13d3918a992
 nhd_statsgo_parent_sbid <- '5728d6ace4b0b13d3918a992'

--- a/_targets.R
+++ b/_targets.R
@@ -1,7 +1,7 @@
 library(targets)
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c("tidyverse","sbtools","sf","nhdplusTools")) 
+tar_option_set(packages = c("tidyverse","sbtools","sf","nhdplusTools", 'purrr')) 
 
 # dir for selected datasets from nhd statsgo
 dir.create('1_fetch/out/statsgo', showWarnings = FALSE)

--- a/_targets.R
+++ b/_targets.R
@@ -3,7 +3,7 @@ library(targets)
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse","sbtools","sf","nhdplusTools", 'purrr')) 
 
-# dir for selected datasets from nhd statsgo
+# dir for selected datasets soil characteristics from nhd statsgo
 dir.create('1_fetch/out/statsgo', showWarnings = FALSE)
 
 source("1_fetch.R")


### PR DESCRIPTION
This PR is ready for review. 

**Added 3 targets:** 
`p1_selected_statsgo_sbid_children`: Pulls the specific child items from the Statsgo soil characteristics data release from Science base. Only interested in Texture attributes and Soil Layer attributes. _(intermediate target)_
`p1_download_statsgo_text_layer_attr`: file target downloading the statsgo zip files _(intermediate target)_
`p1_statsgo_soil_df`: reads in and scopes statsgo dataset + cbinds so that we have 1 target df object with total upstream (TOT), accumulated (ACC), and catchment (CAT)-level values. _(final fetch target)_

**Added 1 function:** 
`sb_read_filter_by_comids()` outputs `p1_statsgo_soil_df`. Built for statsgo but generalizable to any comid-level sb dataset that requires fetching and initial scoping (col selection and aoi row filtering). 

`p1_statsgo_soil_df` output:
```
   COMID ACC_KFACT ACC_KFACT_UP ACC_NO10AVE ACC_NO4AVE ACC_WTDEP CAT_KFACT CAT_KFACT_UP CAT_NO10AVE CAT_NO4AVE CAT_WTDEP TOT_KFACT TOT_KFACT_UP TOT_NO10AVE
1 1748535      0.28         0.24       49.80      57.25      4.89      0.28         0.24       49.80      57.25      4.89      0.28         0.24       49.80
2 1748537      0.28         0.24       51.47      58.49      4.41      0.28         0.24       51.47      58.49      4.41      0.28         0.24       51.47
3 1748539      0.28         0.24       52.71      59.68      3.77      0.28         0.24       52.71      59.68      3.77      0.28         0.24       52.71
4 1748541      0.28         0.24       50.21      57.61      4.80      0.28         0.24       49.75      57.43      5.00      0.28         0.24       50.21
5 1748543      0.28         0.24       51.60      58.85      4.23      0.28         0.24       49.04      56.92      5.29      0.28         0.24       51.60
6 1748545      0.28         0.25       49.03      56.91      5.29      0.28         0.25       49.03      56.91      5.29      0.28         0.25       49.03
  TOT_NO4AVE TOT_WTDEP ACC_SILTAVE ACC_CLAYAVE ACC_SANDAVE CAT_SILTAVE CAT_CLAYAVE CAT_SANDAVE TOT_SILTAVE TOT_CLAYAVE TOT_SANDAVE
1      57.25      4.89       59.74       14.56       25.70       59.74       14.56       25.70       59.74       14.56       25.70
2      58.49      4.41       59.52       13.75       26.73       59.52       13.75       26.73       59.52       13.75       26.73
3      59.68      3.77       58.99       13.47       27.53       58.99       13.47       27.53       58.99       13.47       27.53
4      57.61      4.80       59.72       14.43       25.84       59.90       14.89       25.21       59.72       14.43       25.84
5      58.85      4.23       59.33       14.02       26.65       60.09       15.28       24.63       59.33       14.02       26.65
6      56.91      5.29       60.09       15.28       24.62       60.09       15.28       24.62       60.09       15.28       24.62
```

**Notes of `p1_statsgo_soil_df` target:**
- The final attributes I selected for TOT, ACC, CAT are `c("KFACT","KFACT_UP","NO10AVE",
                                                        "NO4AVE","SILTAVE","CLAYAVE","SANDAVE","WTDEP")` (see 
attr description in abstract and metadata for [layer attr](https://www.sciencebase.gov/catalog/item/5728decfe4b0b13d3918a9aa) and [texture attr](https://www.sciencebase.gov/catalog/item/5728dd46e4b0b13d3918a9a7)). Please let me know if there are any other variables we want 

