### PR TITLE
Compile river-dl input drivers at NHDv2 resolution

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,6 +1,7 @@
 source("1_fetch/src/download_nhdplus_flowlines.R")
 source('1_fetch/src/sb_read_filter_by_comids.R')
 source("1_fetch/src/download_sb_file.R")
+source("1_fetch/src/download_file.R")
 
 p1_targets_list <- list(
   
@@ -87,6 +88,21 @@ p1_targets_list <- list(
   tar_target(
     p1_drb_temp_obs,
     read_csv(p1_drb_temp_obs_csv, col_types = list(seg_id_nat = "c"))
+  ),
+  
+  # Download ref-gages v0.6 to help QC matching NWIS sites to NHDv2 flowlines
+  tar_target(
+    p1_ref_gages_geojson,
+    download_file(url = 'https://github.com/internetofwater/ref_gages/releases/download/v0.6/usgs_nldi_gages.geojson',
+                  fileout = "1_fetch/out/ref_gages.geojson",
+                  mode = "wb", quiet = TRUE)
+  ),
+  
+  # Read in ref-gages v0.6 as an sf object
+  tar_target(
+    p1_ref_gages_sf,
+    sf::st_read(p1_ref_gages_geojson, quiet = TRUE) %>%
+      mutate(COMID_refgages = as.character(nhdpv2_COMID))
   ),
   
   # STATSGO SOIL Characteristics

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -2,6 +2,7 @@ source("1_fetch/src/download_nhdplus_flowlines.R")
 source('1_fetch/src/sb_read_filter_by_comids.R')
 source("1_fetch/src/download_sb_file.R")
 source("1_fetch/src/download_file.R")
+source("1_fetch/src/read_netcdf.R")
 
 p1_targets_list <- list(
   
@@ -88,6 +89,34 @@ p1_targets_list <- list(
   tar_target(
     p1_drb_temp_obs,
     read_csv(p1_drb_temp_obs_csv, col_types = list(seg_id_nat = "c"))
+  ),
+  
+  # Manually download PRMS-SNTemp model driver data from ScienceBase 
+  # using the commented-out code below and place the download zip file in 
+  # 1_fetch/in. Note that you'll be prompted for your username and password
+  # and will need authorization to download the model driver data while the 
+  # data release is still in process:
+  #sbtools::authenticate_sb()
+  #download_sb_file(sb_id = "623e5587d34e915b67d83806",
+  #                 file_name = "uncal_sntemp_input_output.nc.zip",
+  #                 out_dir = "1_fetch/in")
+  tar_target(
+    p1_sntemp_input_output_zip,
+    "1_fetch/in/uncal_sntemp_input_output.nc.zip",
+    format = "file"
+  ),
+  tar_target(
+    p1_sntemp_input_output_nc,
+    unzip(zipfile = p1_sntemp_input_output_zip, 
+          overwrite = TRUE, 
+          exdir = "1_fetch/out"),
+    format = "file"
+  ),
+  
+  # Read in PRMS-SNTemp model driver data
+  tar_target(
+    p1_sntemp_input_output,
+    read_netcdf(p1_sntemp_input_output_nc)
   ),
   
   # Download ref-gages v0.6 to help QC matching NWIS sites to NHDv2 flowlines

--- a/1_fetch/src/download_file.R
+++ b/1_fetch/src/download_file.R
@@ -1,0 +1,20 @@
+download_file <- function(url,fileout,mode,quiet = FALSE){
+  #'
+  #' @description Function to download a file from the internet and return a character
+  #' string indicating the file path
+  #' 
+  #' @param url character string indicating the URL of the file to be downloaded
+  #' @param fileout character string with the name and file path where the downloaded file
+  #' should be saved
+  #' @param mode character string indicating the mode used to write the file; see 
+  #' ??utils::download.file for details
+  #' @param quiet logical (defaults to FALSE); if TRUE, suppresses any status messages
+  
+  # download the file
+  utils::download.file(url, destfile = fileout, mode = mode, quiet = quiet)
+
+  # return the file name including file path and extension
+  return(fileout)
+  
+}
+

--- a/1_fetch/src/read_netcdf.R
+++ b/1_fetch/src/read_netcdf.R
@@ -1,0 +1,74 @@
+#' Read netcdf file and format as an R data frame
+#' 
+#' @details This function contains three different methods for
+#' reading in and formatting netcdf files. Two methods (using 
+#' functions from raster and ncdf4) are commented out and we're 
+#' currently using tidync::hyper_tibble() to format the input/output
+#' data as a data frame.
+#' 
+#' @param nc_file character string indicating the netcdf file name, 
+#' including file path and .nc extension
+#' 
+read_netcdf <- function(nc_file){
+  
+  # Find variables and get netcdf attributes
+  nc <- ncdf4::nc_open(nc_file)
+  variables <- names(nc[['var']])
+  seg_id_nat <- ncdf4::ncvar_get(nc, "seg_id_nat")
+  tunits <- ncdf4::ncatt_get(nc,"time","units")
+  start_date <- sub( "^\\D+", "", tunits$value)
+  time <- ncdf4::ncvar_get(nc, "time")
+  
+  # 1) Read in individual variables from netcdf using {raster}
+  # [Lauren] this implementation is clean and seems to work, but there are 
+  # a couple of issues that I don't know how to address right now: 1) xy is 
+  # set up for lat/lon data and so is reading in seg_id_nat as numeric and 
+  # reformatting all of the values into floats. I haven't been able to figure
+  # out a workaround for that; 2) more importantly, this raster implementation
+  # returns an output that differs from the ncdf4 output(!). Comparing static
+  # attribute values from the 2021 forecasting data release leads me to believe
+  # the ncdf4 code returns the correct values, so what's going on with raster?
+  # Leaving this code here but commented out in case we want to return to this.
+  #ncvars_ls <- lapply(variables, function(i){
+  #  r <- raster::raster(nc_file,varname = i, stopIfNotEqualSpaced = FALSE)
+  #  r_df <- raster::as.data.frame(r, xy = TRUE) %>%
+  #    rename(time = x, seg_id_nat = y, !!i := 3) %>%
+  #    mutate(date = as.Date(as.numeric(time), origin = start_date))
+  #})
+  #names(ncvars_ls) <- variables
+  
+  # 2) Read in individual variables from netcdf using {ncdf4}
+  #ncvars_ls <- lapply(variables, function(i){
+  #  # load variable data
+  #  r <- ncdf4::ncvar_get(nc, i)
+  #  
+  #  # format as a data frame
+  #  r_df <- as.data.frame(r)
+  #  colnames(r_df) <- seg_id_nat
+  #  r_df$time <- seq(time)-1 # seq starts at 1 instead of zero, so subtract 1
+  #  
+  #  # reformat data frame from wide to long 
+  #  r_df_out <- r_df %>%
+  #    pivot_longer(!time, names_to = 'seg_id_nat', values_to = i) %>%
+  #    mutate(date = as.Date(time, origin = start_date)) 
+  #}) 
+  
+  # convert list into a data frame
+  #ncvars_df <- purrr::reduce(ncvars_ls, full_join, by = c('date','time','seg_id_nat')) %>%
+  #  arrange(seg_id_nat, time)
+  
+  # close netcdf file
+  ncdf4::nc_close(nc)
+  
+  # 3) Use tidync package instead: https://ropensci.org/blog/2019/11/05/tidync/
+  ncvars_df <- nc_file %>% 
+    tidync::hyper_tibble() %>% 
+    mutate(date = as.Date(time, origin = start_date)) %>%
+    relocate(seg_id_nat, .before = seg_rain) %>% 
+    relocate(time, .after = seg_id_nat) %>%
+    relocate(date, .after = time)
+  
+  return(ncvars_df)
+  
+}
+

--- a/2_process.R
+++ b/2_process.R
@@ -20,7 +20,8 @@ p2_targets_list <- list(
     p2_nhd_reaches_w_width,
     estimate_mean_width(p1_nhd_reaches, 
                         estimation_method = 'nwis',
-                        network_pos_variable = 'arbolate_sum')
+                        network_pos_variable = 'arbolate_sum',
+                        ref_gages = p1_ref_gages_sf)
   ),
   
   # Compile river-dl input drivers at NHDv2 resolution, including river 

--- a/2_process.R
+++ b/2_process.R
@@ -1,5 +1,6 @@
 source("2_process/src/subset_closest_nhd.R")
 source("2_process/src/estimate_mean_width.R")
+source("2_process/src/write_feather.R")
 
 p2_targets_list <- list(
 
@@ -60,6 +61,14 @@ p2_targets_list <- list(
       left_join(y = p2_input_drivers_prms, by = "segidnat") %>%
       select(COMID, segidnat, PRMS_segid, est_width_m, slope, slopelenkm, slope_len_wtd_mean, 
              lengthkm, min_elev_m, max_elev_m, seg_elev, seg_slope, seg_width) 
+  ),
+  
+  # Save river-dl input drivers at NHDv2 resolution as a feather file
+  tar_target(
+    p2_input_drivers_nhd_feather,
+    write_feather(p2_input_drivers_nhd, "2_process/out/riverdl_inputs_nhdv2.feather"),
+    format = "file"
   )
+  
   
 )

--- a/2_process.R
+++ b/2_process.R
@@ -21,6 +21,21 @@ p2_targets_list <- list(
     estimate_mean_width(p1_nhd_reaches, 
                         estimation_method = 'nwis',
                         network_pos_variable = 'arbolate_sum')
+  ),
+  
+  # Compile river-dl input drivers at NHDv2 resolution, including river 
+  # width (meters), slope (unitless), and min/max elevation (transformed
+  # to meters from cm)
+  tar_target(
+    p2_input_drivers_nhd,
+    p2_nhd_reaches_w_width %>%
+      sf::st_drop_geometry() %>%
+      mutate(COMID = as.character(comid),
+             min_elev_m = minelevsmo/100, 
+             max_elev_m = maxelevsmo/100) %>%
+      left_join(p1_drb_comids_all_tribs, by = "COMID") %>%
+      select(COMID, segidnat, PRMS_segid, est_mean_width_m, slope, lengthkm,
+             min_elev_m, max_elev_m) 
   )
   
 )

--- a/2_process.R
+++ b/2_process.R
@@ -33,9 +33,10 @@ p2_targets_list <- list(
       sf::st_drop_geometry() %>%
       mutate(COMID = as.character(comid),
              min_elev_m = minelevsmo/100, 
-             max_elev_m = maxelevsmo/100) %>%
+             max_elev_m = maxelevsmo/100,
+             slope = if_else(slope == -9998, NA_real_,slope)) %>%
       left_join(p1_drb_comids_all_tribs, by = "COMID") %>%
-      select(COMID, segidnat, PRMS_segid, est_mean_width_m, slope, lengthkm,
+      select(COMID, segidnat, PRMS_segid, est_width_m, slope, lengthkm,
              min_elev_m, max_elev_m) 
   )
   

--- a/2_process.R
+++ b/2_process.R
@@ -1,4 +1,5 @@
 source("2_process/src/subset_closest_nhd.R")
+source("2_process/src/estimate_mean_width.R")
 
 p2_targets_list <- list(
 
@@ -12,6 +13,14 @@ p2_targets_list <- list(
     p2_drb_temp_sites_w_segs,
     subset_closest_nhd(nhd_lines = p1_nhd_reaches_along_NHM,
                        sites = p1_drb_temp_sites_sf)
+  ),
+  
+  # Estimate mean width for each NHDv2 reach 
+  tar_target(
+    p2_nhd_reaches_w_width,
+    estimate_mean_width(p1_nhd_reaches, 
+                        estimation_method = 'nwis',
+                        network_pos_variable = 'arbolate_sum')
   )
   
 )

--- a/2_process.R
+++ b/2_process.R
@@ -36,8 +36,15 @@ p2_targets_list <- list(
              max_elev_m = maxelevsmo/100,
              slope = if_else(slope == -9998, NA_real_,slope)) %>%
       left_join(p1_drb_comids_all_tribs, by = "COMID") %>%
-      select(COMID, segidnat, PRMS_segid, est_width_m, slope, lengthkm,
-             min_elev_m, max_elev_m) 
+      # calculate length-weighted average slope for NHDv2 reaches associated
+      # with each NHM reach. For simplicity, weight by the reach length rather
+      # than another value-added attribute, slopelenkm, which represents the
+      # length over which the NHDv2 attribute slope was computed.
+      group_by(segidnat) %>%
+      mutate(slope_len_wtd_mean = weighted.mean(x = slope, w = lengthkm, na.rm = TRUE)) %>%
+      ungroup() %>%
+      select(COMID, segidnat, PRMS_segid, est_width_m, slope, slopelenkm, 
+             slope_len_wtd_mean, lengthkm, min_elev_m, max_elev_m) 
   )
   
 )

--- a/2_process.R
+++ b/2_process.R
@@ -55,12 +55,15 @@ p2_targets_list <- list(
       # than another value-added attribute, slopelenkm, which represents the
       # length over which the NHDv2 attribute slope was computed.
       group_by(segidnat) %>%
-      mutate(slope_len_wtd_mean = weighted.mean(x = slope, w = lengthkm, na.rm = TRUE)) %>%
+      mutate(slope_len_wtd_mean = weighted.mean(x = slope, w = lengthkm, na.rm = TRUE),
+             seg_width_max = max(est_width_m, na.rm = TRUE), 
+             seg_elev_min = min(min_elev_m, na.rm = TRUE)) %>%
       ungroup() %>%
       # join select attributes from PRMS-SNTemp
       left_join(y = p2_input_drivers_prms, by = "segidnat") %>%
       select(COMID, segidnat, PRMS_segid, est_width_m, slope, slopelenkm, slope_len_wtd_mean, 
-             lengthkm, min_elev_m, max_elev_m, seg_elev, seg_slope, seg_width) 
+             lengthkm, min_elev_m, max_elev_m, seg_elev, seg_slope, seg_width, seg_width_max,
+             seg_elev_min) 
   ),
   
   # Save river-dl input drivers at NHDv2 resolution as a feather file

--- a/2_process/src/estimate_mean_width.R
+++ b/2_process/src/estimate_mean_width.R
@@ -5,11 +5,11 @@
 #' @param buffer_dist_m integer; look for NWIS sites within this distance
 #' in meters. Defaults to 500 m.
 #' @param estimation_method character string; what method should be used 
-#' to estimate NHDflowline widths? valid options include "nwis".
-#' @param network_pos_variable character string; what NHDPlusv2 attribute
-#' should be used to build an empirical regression that predicts mean width?
-#' Valid entries are "arbolate_sum", "upstream_area" and "ma_flow", which is 
-#' the gage-adjusted mean annual flow for a given COMID as indicated by the 
+#' to estimate NHDflowline widths? valid options include "nwis" and "raymond2012".
+#' @param network_pos_variable character string; if estimation_method is 'nwis',
+#' what NHDPlusv2 attribute should be used to build an empirical regression that
+#' predicts mean width? Valid entries are "arbolate_sum", "upstream_area" and "ma_flow", 
+#' which is the gage-adjusted mean annual flow for a given COMID as indicated by the 
 #' value-added attribute QE_MA.
 #' @param ref_gages sf object representing the ref-gages dataset, downloaded from
 #' https://github.com/internetofwater/ref_gages. ref_gages should contain the
@@ -153,9 +153,22 @@ estimate_mean_width <- function(nhd_lines, buffer_dist_m = 500, estimation_metho
       nhd_lines_out <- nhd_lines %>%
         mutate(est_width_m = a_coeff_qema * ((qe_ma * 0.0283168)^b_coeff_qema))
     }
-  }    
+  }
+  
+  # 2) Another approach is to estimate width using the empirical relationship
+  # between synthesized measured widths and discharge presented in Raymond et
+  # al. 2012, https://doi.org/10.1215/21573689-1597669. This dataset likely
+  # skews more toward smaller streams and rivers compared to NWIS measurements.
+  if(estimation_method == 'raymond2012'){
+    a_coeff_raymond <- 12.88
+    b_coeff_raymond <- 0.42
     
-    return(nhd_lines_out)
+    nhd_lines_out <- nhd_lines %>%
+      mutate(est_width_m = a_coeff_raymond * ((qe_ma * 0.0283168)^b_coeff_raymond))
+    
+  }
+  
+  return(nhd_lines_out)
 
 }
 

--- a/2_process/src/estimate_mean_width.R
+++ b/2_process/src/estimate_mean_width.R
@@ -131,26 +131,27 @@ estimate_mean_width <- function(nhd_lines, buffer_dist_m = 500, estimation_metho
                                        fit_qe_ma$r.squared))
     
     # apply regression coefficients to predict width across nhdv2 reaches
+    # width = a * (arb_sum^b)
     if(network_pos_variable == "arbolate_sum"){
-      slope_arbsum <- width_fits$slope[width_fits$network_pos_variable == "arbolate_sum"]
-      int_arbsum <- width_fits$intercept[width_fits$network_pos_variable == "arbolate_sum"]
+      a_coeff_arbsum <- 10^width_fits$intercept[width_fits$network_pos_variable == "arbolate_sum"]
+      b_coeff_arbsum <- width_fits$slope[width_fits$network_pos_variable == "arbolate_sum"]
       
       nhd_lines_out <- nhd_lines %>%
-        mutate(est_mean_width_m = arbolatesu * slope_arbsum + int_arbsum)
+        mutate(est_width_m = a_coeff_arbsum * (arbolatesu^b_coeff_arbsum))
     }
     if(network_pos_variable == "upstream_area"){
-      slope_totda <- width_fits$slope[width_fits$network_pos_variable == "upstream_area"]
-      int_totda <- width_fits$intercept[width_fits$network_pos_variable == "upstream_area"]
+      a_coeff_totda <- 10^width_fits$intercept[width_fits$network_pos_variable == "upstream_area"]
+      b_coeff_totda <- width_fits$slope[width_fits$network_pos_variable == "upstream_area"]
       
       nhd_lines_out <- nhd_lines %>%
-        mutate(est_mean_width_m = totdasqkm * slope_totda + int_totda)
+        mutate(est_width_m = a_coeff_totda * (totdasqkm^b_coeff_totda))
     }
     if(network_pos_variable == "ma_flow"){
-      slope_qe_ma <- width_fits$slope[width_fits$network_pos_variable == "ma_flow"]
-      int_qe_ma <- width_fits$intercept[width_fits$network_pos_variable == "ma_flow"]
+      a_coeff_qema <- 10^width_fits$intercept[width_fits$network_pos_variable == "ma_flow"]
+      b_coeff_qema <- width_fits$slope[width_fits$network_pos_variable == "ma_flow"]
       
       nhd_lines_out <- nhd_lines %>%
-        mutate(est_mean_width_m = qe_ma * slope_qe_ma + int_qe_ma)
+        mutate(est_width_m = a_coeff_qema * ((qe_ma * 0.0283168)^b_coeff_qema))
     }
   }    
     

--- a/2_process/src/estimate_mean_width.R
+++ b/2_process/src/estimate_mean_width.R
@@ -1,0 +1,197 @@
+#' Function to estimate mean width for an NHDPlusv2 reach
+#'
+#' @param nhd_lines sf linestring containing the NHDPlusv2 flowlines. Must
+#' contain column COMID indicating the unique reach identifier
+#' @param buffer_dist_m integer; look for NWIS sites within this distance
+#' in meters. Defaults to 500 m.
+#' @param estimation_method character string; what method should be used 
+#' to estimate NHDflowline widths? valid options include "nwis".
+#' @param network_pos_variable character string; what NHDPlusv2 attribute
+#' should be used to build an empirical regression that predicts mean width?
+#' Defaults to "arbolate_sum". Other valid entries are "upstream_area" and
+#' "ma_flow", which is the gage-adjusted mean annual flow for a given COMID
+#' as indicated by the value-added attribute QE_MA.
+#' 
+estimate_mean_width <- function(nhd_lines, 
+                                buffer_dist_m = 500, 
+                                estimation_method = 'nwis', 
+                                network_pos_variable = 'arbolate_sum'){
+  
+  # Check that user entries match expected inputs
+  stopifnot("Value provided for estimation_method is not a valid entry" =
+              estimation_method %in% c("nwis"))
+  stopifnot("Value provided for network_pos_variable is not a valid entry" =
+              network_pos_variable %in% c("arbolate_sum","upstream_area","ma_flow"))
+  
+  # 1) One approach is to estimate width using an empirical relationship
+  # between measured width and upstream area that is developed using
+  # USGS field measurements of width. 
+  if(estimation_method == 'nwis'){
+    
+    message("Downloading width data from NWIS...")
+    
+    # return a list of nwis sites within the bounding box of nhd_lines
+    nwis_sites <- dataRetrieval::whatNWISsites(bBox = sf::st_bbox(nhd_lines),
+                                               parameterCd = "00060")
+    
+    nwis_sites_sf <- nwis_sites %>% 
+      sf::st_as_sf(coords = c('dec_long_va','dec_lat_va'), crs = 4269) %>%
+      sf::st_transform(st_crs(nhd_lines))
+    
+    # The bounding box approach above returns more sites than we're
+    # interested in, omit sites that aren't within some distance of
+    # the given nhd network 
+    nwis_sites_along_nhd <- nwis_sites_sf %>%
+      sf::st_filter(y = nhd_lines, 
+                    .predicate = st_is_within_distance,
+                    dist = units::set_units(buffer_dist_m, m))
+
+    # Join nwis sites to nearest nhd flowline
+    nwis_sites_snapped <- nwis_sites_along_nhd %>%
+      sf::st_transform(st_crs(nhd_lines)) %>%
+      sf::st_join(y = nhd_lines, join = st_nearest_feature)
+    
+    # Download width measurements from NWIS
+    nwis_widths <- nwis_sites_snapped %>%
+      sf::st_drop_geometry() %>%
+      split(.,.$site_no) %>%
+      lapply(., function(x){
+        tryCatch(summarize_nwis_widths(x$site_no), 
+                 error = function(cond){
+                   return(NULL)
+                 },
+                 warning = function(cond){
+                   return(NULL)
+                 })
+      }) %>%
+      bind_rows()
+    
+    # create empirical relationship between NWIS widths and arbolate sum, 
+    # as in this USGS report, https://pubs.usgs.gov/sir/2021/5116/sir20215116.pdf,
+    # or by total upstream area, or by the gage-adjusted estimated mean annual 
+    # discharge (NHDPlus attribute qe_ma)
+    message(sprintf(
+      paste0("Estimating width for NHDPlusv2 flowlines based on empirical fit ",
+             "between NWIS measurements and attribute %s..."), network_pos_variable))
+    
+    nwis_sites_w_width <- nwis_widths %>%
+      left_join(nwis_sites_snapped, by = "site_no")
+      
+    fit_arbsum <- summary(lm(log10(width_m) ~ log10(arbolatesu), data = nwis_sites_w_width))
+    fit_totda <- summary(lm(log10(width_m) ~ log10(totdasqkm), data = nwis_sites_w_width))
+    fit_qe_ma <- summary(lm(log10(width_m) ~ log10(qe_ma), data = nwis_sites_w_width))
+    
+    width_fits <- tibble(network_pos_variable = c('arbolate_sum','upstream_area','ma_flow'),
+                         slope = c(fit_arbsum$coefficients[2],
+                                   fit_totda$coefficients[2],
+                                   fit_qe_ma$coefficients[2]),
+                         intercept = c(fit_arbsum$coefficients[1],
+                                       fit_totda$coefficients[1],
+                                       fit_qe_ma$coefficients[1]),
+                         r.squared = c(fit_arbsum$r.squared, 
+                                       fit_totda$r.squared, 
+                                       fit_qe_ma$r.squared))
+    
+    if(network_pos_variable == "arbolate_sum"){
+      slope_arbsum <- width_fits$slope[width_fits$network_pos_variable == "arbolate_sum"]
+      int_arbsum <- width_fits$intercept[width_fits$network_pos_variable == "arbolate_sum"]
+      
+      nhd_lines_out <- nhd_lines %>%
+        mutate(est_mean_width_m = arbolatesu * slope_arbsum + int_arbsum)
+    }
+    if(network_pos_variable == "upstream_area"){
+      slope_totda <- width_fits$slope[width_fits$network_pos_variable == "upstream_area"]
+      int_totda <- width_fits$intercept[width_fits$network_pos_variable == "upstream_area"]
+      
+      nhd_lines_out <- nhd_lines %>%
+        mutate(est_mean_width_m = totdasqkm * slope_totda + int_totda)
+    }
+    if(network_pos_variable == "ma_flow"){
+      slope_qe_ma <- width_fits$slope[width_fits$network_pos_variable == "ma_flow"]
+      int_qe_ma <- width_fits$intercept[width_fits$network_pos_variable == "ma_flow"]
+      
+      nhd_lines_out <- nhd_lines %>%
+        mutate(est_mean_width_m = qe_ma * slope_qe_ma + int_qe_ma)
+    }
+  }    
+    
+    return(nhd_lines_out)
+
+}
+
+
+#' Function to download USGS in situ field measurements of river width
+#' 
+#' @param site_no character string indicating the USGS site number
+#' 
+#' @examples download_nwis_widths("01481000")
+#' 
+download_nwis_widths <- function(site_no){
+  
+  # download width measurements from NWIS
+  width_data <- dataRetrieval::readNWISmeas(siteNumbers = site_no, expanded = TRUE)
+    
+  # Format in situ width measurements
+  width_data_out <- width_data %>%
+    filter(!is.na(chan_width)) %>%
+    mutate(width_m = chan_width * 0.3048) 
+  
+  return(width_data_out)
+  
+}
+
+
+
+#' Function to download USGS in situ field measurements of river width
+#' and return the median width in meters.
+#' 
+#' @param site_no character string indicating the USGS site number
+#' @param earliest_date character string formatted as "YYYY-MM-DD", will 
+#' return width measurements made on or after this date. Defaults to NULL, 
+#' which returns all available width measurements.
+#' @param latest_date character string formatted as "YYYY-MM-DD", will 
+#' return width measurements made on or before this date. Defaults to NULL,
+#' which returns all available width measurements.
+#' 
+#' @examples summarize_nwis_widths("01481000", earliest_date = "1980-10-01")
+#'
+summarize_nwis_widths <- function(site_no, earliest_date = NULL, latest_date = NULL){
+  
+  # Download width data from NWIS
+  width_data <- download_nwis_widths(site_no)
+  
+  # Summarize in situ field widths
+  width_data_out <- width_data %>%
+    # For days with multiple width measurements, summarize
+    # data into a single width value for that date:
+    group_by(measurement_dt) %>%
+    summarize(site_no = unique(site_no),
+              width_median_dt = median(width_m),
+              .groups = 'drop') %>%
+    # If `earliest_date` is not NULL, return only width measurements
+    # made on or after `earliest_date`:
+    {
+      if(!is.null(earliest_date)){
+        filter(.,measurement_dt >= earliest_date)
+      } else {.}
+    } %>%
+    # If 'latest_date' is not NULL, return only width measurements
+    # made on or before `latest_date`:
+    {
+      if(!is.null(latest_date)){
+        filter(.,measurement_dt <= latest_date)
+      } else {.}
+    } %>%
+    summarize(site_no = unique(site_no),
+              width_m = median(width_median_dt),
+              width_measures_n = n(),
+              .groups = 'drop')
+  
+  return(width_data_out)
+  
+}
+
+  
+
+
+

--- a/2_process/src/write_feather.R
+++ b/2_process/src/write_feather.R
@@ -1,0 +1,16 @@
+#' Function to save data frames as a feather file
+#' 
+#' @param data data frame object to save as a feather file
+#' @param file_out character string indicating the name of the output file,
+#' including file path and .feather extension
+#' 
+write_feather <- function(data, file_out){
+  
+  # save data as a feather file
+  arrow::write_feather(data, file_out)
+  
+  # return the file name
+  return(file_out)
+  
+}
+

--- a/_targets.R
+++ b/_targets.R
@@ -10,9 +10,11 @@ source("1_fetch.R")
 source("2_process.R")
 
 # Define the url for the NHGFv1 to NHDv2 crosswalk 
-# see https://github.com/USGS-R/drb-network-prep/commit/614177cc96ed955db364dc0a1dc7d03adffbd33b
+# Note that there are different versions of the crosswalk table that might be best suited
+# to different use cases (e.g. retain divergences? retain zero-area flowlines?)
+# see https://github.com/USGS-R/drb-network-prep/commit/3637931f5a17469a4234eaed3d20ed44ba45958d
 GFv1_NHDv2_xwalk_url <- paste0("https://raw.githubusercontent.com/USGS-R/drb-network-prep/",
-                               "614177cc96ed955db364dc0a1dc7d03adffbd33b",
+                               "3637931f5a17469a4234eaed3d20ed44ba45958d",
                                "/2_process/out/GFv1_NHDv2_xwalk.csv")
 
 

--- a/_targets.R
+++ b/_targets.R
@@ -1,7 +1,8 @@
 library(targets)
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c("tidyverse","sbtools","sf","nhdplusTools", 'purrr')) 
+tar_option_set(packages = c("tidyverse","sbtools","sf","nhdplusTools", "purrr",
+                            "arrow", "tidync", "ncdf4")) 
 
 # dir for selected datasets soil characteristics from nhd statsgo
 dir.create('1_fetch/out/statsgo', showWarnings = FALSE)


### PR DESCRIPTION
This PR includes two new targets. `p2_nhd_reaches_w_width` adds estimates of width to the NHDPlusv2 attribute table, and `p2_input_drivers_nhd` compiles model input drivers at the NHDv2 resolution. Model input drivers include slope, width, reach length, and min/max segment elevation.

There are three new functions added in `2_process/src/estimate_mean_width.R`. The function `estimate_mean_width()` provides a few different options for estimating reach width. The first is to use empirical relationships between NWIS width measurements  and various NHDPlusv2 attributes - arbolate sum, total upstream area, _or_ estimated mean annual flow - within the spatial domain. To use NWIS field measurements to inform our width estimates, we download NWIS widths and summarize those field observations into a single mean value for each site using calls to `download_nwis_widths()` and `summarize_nwis_widths()`. Another approach allows a user to estimate reach width using empirical relationships previously synthesized by [Raymond et al. 2012](https://doi.org/10.1215/21573689-1597669). Regardless of the approach used, width estimates come from generalized equations and should not necessarily be interpreted as 'truth' for any individual reach. 

I compared how these model input drivers compare to those for the paired NHM segments. There are some notable discrepancies in addition to the expected scatter. I'd be interested in your thoughts as to how these differences might impact model behavior or our ability to compare model runs. 

![compare](https://user-images.githubusercontent.com/8785034/178054240-468b1dea-0641-4869-ba70-f4b4793867f1.png)





Closes #9 