### PR TITLE
Add nhd met data

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -27,6 +27,15 @@ p1_targets_list <- list(
       rename(COMID = comid_cat)
   ),
   
+  # Reshape crosswalk table to return all COMIDs that overlap each NHM segment.
+  tar_target(
+    p1_drb_comids_segs, 
+    p1_GFv1_NHDv2_xwalk %>%
+      select(PRMS_segid, segidnat, comid_seg) %>% 
+      tidyr::separate_rows(comid_seg,sep=";") %>% 
+      rename(COMID = comid_seg)
+  ),
+  
   # Use crosswalk table to fetch all NHDv2 reaches in the DRB. These COMIDs 
   # should be used for preparing feature data, including aggregating feature 
   # values from the NHD-scale to the NHM-scale and/or for deriving feature 
@@ -34,6 +43,12 @@ p1_targets_list <- list(
   tar_target(
     p1_nhd_reaches,
     download_nhdplus_flowlines(p1_drb_comids_all_tribs$COMID)
+  ),
+  
+  # Use crosswalk table to fetch just the NHDv2 reaches that overlap the NHM network.
+  tar_target(
+    p1_nhd_reaches_along_NHM,
+    download_nhdplus_flowlines(p1_drb_comids_segs$COMID)
   ),
   
   # Download all NHDPlusv2 catchments in the DRB (may take awhile to run).

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -7,22 +7,17 @@ source("1_fetch/src/read_netcdf.R")
 
 p1_targets_list <- list(
   
-  # Read in the NHM - NHDv2 crosswalk file
+  # Important! This pipeline uses two versions of the NHM-NHDv2 crosswalk table
+  # for different purposes. All targets pertaining to the "dendritic" version
+  # of the crosswalk table will include the string "dendritic" in the name.
+  # Read in the NHM - NHDv2 crosswalk file that contains all NHDPlusv2 COMIDs
+  # in the DRB (including divergent reaches and reaches without catchments)
   tar_target(
     p1_GFv1_NHDv2_xwalk,
     read_csv(GFv1_NHDv2_xwalk_url,col_types = cols(.default = "c"))
   ),
   
-  # Reshape crosswalk table to return all COMIDs that overlap each NHM segment
-  tar_target(
-    p1_drb_comids_segs, 
-    p1_GFv1_NHDv2_xwalk %>%
-      select(PRMS_segid, segidnat, comid_seg) %>% 
-      tidyr::separate_rows(comid_seg,sep=";") %>% 
-      rename(COMID = comid_seg)
-  ),
-  
-  # Reshape crosswalk table to return all COMIDs that drain to each NHM segment
+  # Reshape crosswalk table to return all COMIDs that drain to each NHM segment.
   tar_target(
     p1_drb_comids_all_tribs, 
     p1_GFv1_NHDv2_xwalk %>%
@@ -31,13 +26,10 @@ p1_targets_list <- list(
       rename(COMID = comid_cat)
   ),
   
-  # Use crosswalk table to fetch just the NHDv2 reaches that overlap the NHM network
-  tar_target(
-    p1_nhd_reaches_along_NHM,
-    download_nhdplus_flowlines(p1_drb_comids_segs$COMID)
-  ),
-  
-  # Use crosswalk table to fetch all NHDv2 reaches in the DRB 
+  # Use crosswalk table to fetch all NHDv2 reaches in the DRB. These COMIDs 
+  # should be used for preparing feature data, including aggregating feature 
+  # values from the NHD-scale to the NHM-scale and/or for deriving feature 
+  # values from raster data.
   tar_target(
     p1_nhd_reaches,
     download_nhdplus_flowlines(p1_drb_comids_all_tribs$COMID)
@@ -68,6 +60,32 @@ p1_targets_list <- list(
     format = "file"
   ),
   
+  # Read in the NHM - NHDv2 crosswalk file that corresponds to the *dendritic* 
+  # network only (i.e., divergent reaches have been omitted). This version of
+  # the crosswalk table was used to build the network distance matrix in 
+  # drb-network-prep, and so includes the COMIDs that we will make predictions
+  # on in the NHD-downscaling set of experiments. 
+  tar_target(
+    p1_GFv1_NHDv2_xwalk_dendritic,
+    read_csv(GFv1_NHDv2_xwalk_dendritic_url,col_types = cols(.default = "c"))
+  ),
+  
+  # Reshape dendritic crosswalk table to return all COMIDs that overlap each 
+  # NHM segment
+  tar_target(
+    p1_drb_comids_dendritic_segs, 
+    p1_GFv1_NHDv2_xwalk_dendritic %>%
+      select(PRMS_segid, segidnat, comid_seg) %>% 
+      tidyr::separate_rows(comid_seg,sep=";") %>% 
+      rename(COMID = comid_seg)
+  ),
+  
+  # Use crosswalk table to fetch just the dendritic NHDv2 reaches that overlap
+  # the NHM network
+  tar_target(
+    p1_dendritic_nhd_reaches_along_NHM,
+    download_nhdplus_flowlines(p1_drb_comids_dendritic_segs$COMID)
+  ),
   
   # Manually download temperature site locations from ScienceBase using the
   # commented-out code below and place the downloaded zip file in 1_fetch/in. 

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -78,7 +78,6 @@ p1_targets_list <- list(
   # download_sb_file(sb_id = "623e54c4d34e915b67d83580",
   #                 file_name = "study_monitoring_sites.zip",
   #                 out_dir = "1_fetch/in")
-
   tar_target(
     p1_drb_temp_sites_shp,
     {
@@ -145,6 +144,17 @@ p1_targets_list <- list(
   tar_target(
     p1_sntemp_input_output,
     read_netcdf(p1_sntemp_input_output_nc)
+  ),
+  
+  # Read in meteorological data aggregated to NHDPlusV2 catchments for the 
+  # DRB (prepped in https://github.com/USGS-R/drb_gridmet_tools). Note that
+  # the DRB met data file must be stored in 1_fetch/in. If working outside
+  # of tallgrass/caldera, this file will need to be downloaded from the
+  # PGDL-DO project's S3 bucket and manually placed in 1_fetch/in.
+  tar_target(
+    p1_drb_nhd_gridmet,
+    "1_fetch/in/drb_climate_2022_06_14.nc",
+    format = "file"
   ),
   
   # Download ref-gages v0.6 to help QC matching NWIS sites to NHDv2 flowlines

--- a/2_process.R
+++ b/2_process.R
@@ -91,7 +91,7 @@ p2_targets_list <- list(
   # (COMID) that intersect the NHM segments. `subset_nc_to_comid()` originally
   # developed by Jeff Sadler as part of the PGDL-DO project:
   # https://github.com/USGS-R/drb-do-ml/blob/main/2_process/src/subset_nc_to_comid.py
-  # The resulting target is ~1.6 GB.
+  # The resulting target is ~0.6 GB.
   tar_target(
     p2_met_data_nhd_mainstem_reaches,
     {
@@ -99,7 +99,13 @@ p2_targets_list <- list(
       subset_nc_to_comids(p1_drb_nhd_gridmet, 
                           p2_nhd_mainstem_reaches_w_width$comid) %>%
         as_tibble() %>%
-        relocate(c(COMID,time), .before = "tmmx")
+        relocate(c(COMID,time), .before = "tmmx") %>%
+        # rename gridmet columns to conform to PRMS-SNTemp names
+        # currently used in river-dl
+        select(COMID, time, tmmn, srad, pr) %>%
+        rename(seg_tave_air = tmmn,
+               seginc_swrad = srad,
+               seg_rain = pr)
     }
   ),
   

--- a/2_process.R
+++ b/2_process.R
@@ -108,11 +108,13 @@ p2_targets_list <- list(
                           p2_nhd_mainstem_reaches_w_width$comid) %>%
         as_tibble() %>%
         relocate(c(COMID,time), .before = "tmmx") %>%
+        # convert gridmet precip units from inches to meters, and temperature
+        # units from degrees Farenheit to degrees Celsius
+        mutate(seg_tave_air = ((tmmn - 32) * (5/9)),
+               seg_rain = pr * 0.0254) %>%
         # rename gridmet columns to conform to PRMS-SNTemp names used in river-dl
-        select(COMID, time, tmmn, srad, pr) %>%
-        rename(seg_tave_air = tmmn,
-               seginc_swrad = srad,
-               seg_rain = pr)
+        select(COMID, time, seg_tave_air, srad, seg_rain) %>%
+        rename(seginc_swrad = srad)
     }
   ),
   

--- a/2_process.R
+++ b/2_process.R
@@ -108,12 +108,17 @@ p2_targets_list <- list(
                           p2_nhd_mainstem_reaches_w_width$comid) %>%
         as_tibble() %>%
         relocate(c(COMID,time), .before = "tmmx") %>%
+        # format dates
+        mutate(date = lubridate::as_date(time, tz = "UTC")) %>%
         # convert gridmet precip units from inches to meters, and temperature
-        # units from degrees Farenheit to degrees Celsius
+        # units from degrees Farenheit to degrees Celsius. Note that we are 
+        # using daily minimum temperature from gridmet and calling that 
+        # "seg_tave_air", which we assume corresponds approximately to the 
+        # PRMS-SNTemp variable with the same name. 
         mutate(seg_tave_air = ((tmmn - 32) * (5/9)),
                seg_rain = pr * 0.0254) %>%
         # rename gridmet columns to conform to PRMS-SNTemp names used in river-dl
-        select(COMID, time, seg_tave_air, srad, seg_rain) %>%
+        select(COMID, date, seg_tave_air, srad, seg_rain) %>%
         rename(seginc_swrad = srad)
     }
   ),
@@ -159,7 +164,7 @@ p2_targets_list <- list(
   tar_target(
     p2_input_drivers_nhd_zarr,
     write_df_to_zarr(p2_input_drivers_nhd, 
-                     index_cols = c("time", "COMID"), 
+                     index_cols = c("date", "COMID"), 
                      "2_process/out/nhdv2_inputs_io.zarr"),
     format = "file"
   )

--- a/2_process.R
+++ b/2_process.R
@@ -142,7 +142,7 @@ p2_targets_list <- list(
   tar_target(
     p2_input_drivers_nhd_zarr,
     write_df_to_zarr(p2_input_drivers_nhd, 
-                     index_cols = c("COMID", "time"), 
+                     index_cols = c("time", "COMID"), 
                      "2_process/out/nhdv2_inputs_io.zarr"),
     format = "file"
   )

--- a/2_process.R
+++ b/2_process.R
@@ -5,6 +5,14 @@ source("2_process/src/write_data.R")
 
 p2_targets_list <- list(
 
+  # Subset NHDv2 reaches that overlap the NHM network to only include those 
+  # that have a corresponding catchment (and meteorological data)
+  tar_target(
+    p2_nhd_reaches_along_NHM_w_cats,
+    p1_nhd_reaches_along_NHM %>%
+      filter(areasqkm > 0)
+  ),
+  
   # Match temperature monitoring locations to "mainstem" NHDPlusv2 flowline
   # reaches, i.e. those that NHD reaches that intersect the NHM river network.
   # Note that this site-to-segment matching procedure emulates the process
@@ -13,7 +21,7 @@ p2_targets_list <- list(
   # for which the downstream vertex (endpoint) is close to the site point.
   tar_target(
     p2_drb_temp_sites_w_segs,
-    subset_closest_nhd(nhd_lines = p1_nhd_reaches_along_NHM,
+    subset_closest_nhd(nhd_lines = p2_nhd_reaches_along_NHM_w_cats,
                        sites = p1_drb_temp_sites_sf)
   ),
   
@@ -60,7 +68,7 @@ p2_targets_list <- list(
   # Estimate mean width for each "mainstem" NHDv2 reach 
   tar_target(
     p2_nhd_mainstem_reaches_w_width,
-    estimate_mean_width(p1_nhd_reaches_along_NHM, 
+    estimate_mean_width(p2_nhd_reaches_along_NHM_w_cats, 
                         estimation_method = 'nwis',
                         network_pos_variable = 'arbolate_sum',
                         ref_gages = p1_ref_gages_sf)
@@ -82,6 +90,7 @@ p2_targets_list <- list(
   # (COMID) that intersect the NHM segments. `subset_nc_to_comid()` originally
   # developed by Jeff Sadler as part of the PGDL-DO project:
   # https://github.com/USGS-R/drb-do-ml/blob/main/2_process/src/subset_nc_to_comid.py
+  # The resulting target is ~1.6 GB.
   tar_target(
     p2_met_data_nhd_mainstem_reaches,
     {

--- a/2_process.R
+++ b/2_process.R
@@ -138,11 +138,11 @@ p2_targets_list <- list(
     }
   ),
   
-  # Save river-dl input drivers at NHDv2 resolution as a feather file
+  # Save river-dl input drivers at NHDv2 resolution as a zarr data store
   tar_target(
     p2_input_drivers_nhd_zarr,
     write_df_to_zarr(p2_input_drivers_nhd, 
-                     index_cols = c("COMID"), 
+                     index_cols = c("COMID", "time"), 
                      "2_process/out/nhdv2_inputs_io.zarr"),
     format = "file"
   )

--- a/2_process.R
+++ b/2_process.R
@@ -9,8 +9,8 @@ p2_targets_list <- list(
   # Subset NHDv2 reaches that overlap the NHM network to only include those 
   # that have a corresponding catchment (and meteorological data)
   tar_target(
-    p2_nhd_reaches_along_NHM_w_cats,
-    p1_nhd_reaches_along_NHM %>%
+    p2_dendritic_nhd_reaches_along_NHM_w_cats,
+    p1_dendritic_nhd_reaches_along_NHM %>%
       filter(areasqkm > 0)
   ),
   
@@ -22,7 +22,7 @@ p2_targets_list <- list(
   # for which the downstream vertex (endpoint) is close to the site point.
   tar_target(
     p2_drb_temp_sites_w_segs,
-    subset_closest_nhd(nhd_lines = p2_nhd_reaches_along_NHM_w_cats,
+    subset_closest_nhd(nhd_lines = p2_dendritic_nhd_reaches_along_NHM_w_cats,
                        sites = p1_drb_temp_sites_sf)
   ),
   
@@ -69,7 +69,7 @@ p2_targets_list <- list(
   # Estimate mean width for each "mainstem" NHDv2 reach 
   tar_target(
     p2_nhd_mainstem_reaches_w_width,
-    estimate_mean_width(p2_nhd_reaches_along_NHM_w_cats, 
+    estimate_mean_width(p2_dendritic_nhd_reaches_along_NHM_w_cats, 
                         estimation_method = 'nwis',
                         network_pos_variable = 'arbolate_sum',
                         ref_gages = p1_ref_gages_sf)
@@ -135,7 +135,7 @@ p2_targets_list <- list(
   # so we are using seginc_potet from PRMS-SNTemp and assuming that there is 
   # not much intra-segment variation in potential ET among NHD reaches that 
   # contribute to a given NHM segment. The resulting target contains 15,800 
-  # days of climate data across each of 3,182 COMIDs = 50,275,600 total rows.
+  # days of climate data across each of 3,173 COMIDs = 50,133,400 total rows.
   tar_target(
     p2_input_drivers_nhd,
     {

--- a/2_process.R
+++ b/2_process.R
@@ -111,11 +111,12 @@ p2_targets_list <- list(
         # format dates
         mutate(date = lubridate::as_date(time, tz = "UTC")) %>%
         # convert gridmet precip units from inches to meters, and temperature
-        # units from degrees Farenheit to degrees Celsius. Note that we are 
-        # using daily minimum temperature from gridmet and calling that 
-        # "seg_tave_air", which we assume corresponds approximately to the 
-        # PRMS-SNTemp variable with the same name. 
-        mutate(seg_tave_air = ((tmmn - 32) * (5/9)),
+        # units from degrees Farenheit to degrees Celsius. 
+        # Note that we average the daily minimum and maximum temperatures from
+        # gridmet and call that "seg_tave_air", which we assume corresponds 
+        # approximately to the PRMS-SNTemp variable with the same name. 
+        mutate(tmmean = rowMeans(select(., c(tmmn,tmmx))),
+               seg_tave_air = ((tmmean - 32) * (5/9)),
                seg_rain = pr * 0.0254) %>%
         # rename gridmet columns to conform to PRMS-SNTemp names used in river-dl
         select(COMID, date, seg_tave_air, srad, seg_rain) %>%

--- a/2_process.R
+++ b/2_process.R
@@ -106,12 +106,14 @@ p2_targets_list <- list(
   # Compile river-dl input drivers at NHDv2 resolution, including river width
   # (meters), slope (unitless), and min/max elevation (meters). Note that these
   # input drivers represent "mainstem" NHDv2 reaches only (i.e., those reaches
-  # that intersect the NHM fabric).
+  # that intersect the NHM fabric). The resulting target contains 15,869 days of
+  # climate data across each of 3,182 COMIDs = 50,495,158 total rows.
   tar_target(
     p2_input_drivers_nhd,
-    combine_nhd_input_drivers(p2_nhd_mainstem_reaches_w_width,
-                              p2_input_drivers_prms,
-                              p1_drb_comids_all_tribs)
+    combine_nhd_input_drivers(nhd_flowlines = p2_nhd_mainstem_reaches_w_width,
+                              prms_inputs = p2_input_drivers_prms,
+                              nhd_nhm_xwalk = p1_drb_comids_all_tribs,
+                              climate_inputs = p2_met_data_nhd_mainstem_reaches)
   ),
   
   # Save river-dl input drivers at NHDv2 resolution as a feather file

--- a/2_process.R
+++ b/2_process.R
@@ -78,6 +78,21 @@ p2_targets_list <- list(
       select(segidnat, seg_elev, seg_slope, seg_width)
   ),
   
+  # Subset the DRB meteorological data to only include the NHDPlusv2 catchments 
+  # (COMID) that intersect the NHM segments. `subset_nc_to_comid()` originally
+  # developed by Jeff Sadler as part of the PGDL-DO project:
+  # https://github.com/USGS-R/drb-do-ml/blob/main/2_process/src/subset_nc_to_comid.py
+  tar_target(
+    p2_met_data_nhd_mainstem_reaches,
+    {
+      reticulate::source_python("2_process/src/subset_nc_to_comid.py")
+      subset_nc_to_comids(p1_drb_nhd_gridmet, 
+                          p2_nhd_mainstem_reaches_w_width$comid) %>%
+        as_tibble() %>%
+        relocate(c(COMID,time), .before = "tmmx")
+    }
+  ),
+  
   # Compile river-dl input drivers at NHDv2 resolution, including river width
   # (meters), slope (unitless), and min/max elevation (transformed to meters
   # from cm). Note that these input drivers represent "mainstem" NHDv2 reaches 

--- a/2_process/src/combine_nhd_input_drivers.R
+++ b/2_process/src/combine_nhd_input_drivers.R
@@ -68,7 +68,8 @@ combine_nhd_input_drivers <- function(nhd_flowlines, prms_inputs, nhd_nhm_xwalk,
     left_join(y = mutate(climate_inputs, COMID = as.character(COMID)), 
                          by = "COMID") %>%
     relocate(segidnat, .after = COMID) %>%
-    relocate(subsegid, .after = segidnat)
+    relocate(subsegid, .after = segidnat) %>%
+    relocate(time, .after = subsegid)
   
   return(nhd_all_inputs)
 

--- a/2_process/src/combine_nhd_input_drivers.R
+++ b/2_process/src/combine_nhd_input_drivers.R
@@ -70,9 +70,9 @@ prepare_nhd_static_inputs <- function(nhd_flowlines, prms_inputs, nhd_nhm_xwalk)
 #' mean width, reach slope, reach elevation, and meteorological driver data.
 #' 
 #' @param nhd_static_inputs data frame containing NHDPlusv2 static input data.
-#' Must contain column "COMID".
+#' Must contain columns "COMID" and "date".
 #' @param climate_inputs data frame containing daily meteorological data to join
-#' with the NHDPlusv2 static attributes. Must contain column "COMID".
+#' with the NHDPlusv2 static attributes. Must contain columns "COMID" and "date".
 #' @param prms_dynamic_inputs data frame containing daily dynamic inputs from the
 #' PRMS-SNTemp model. Must include columns "date".
 #' @param earliest_date character string with format "YYYY-MM-DD" that indicates
@@ -95,13 +95,11 @@ combine_nhd_input_drivers <- function(nhd_static_inputs, climate_inputs, prms_dy
   nhd_all_inputs <- nhd_static_inputs %>%
     left_join(y = mutate(climate_inputs, COMID = as.character(COMID)), 
               by = "COMID") %>%
-    mutate(date = lubridate::as_date(time)) %>%
     left_join(y = prms_dynamic_inputs, by = c("segidnat","date")) %>%
     filter(date >= earliest_date, date <= latest_date) %>%
     relocate(segidnat, .after = COMID) %>%
     relocate(subsegid, .after = segidnat) %>%
-    relocate(time, .after = subsegid) %>%
-    select(-date)
+    relocate(date, .after = subsegid) 
   
   return(nhd_all_inputs)
   

--- a/2_process/src/combine_nhd_input_drivers.R
+++ b/2_process/src/combine_nhd_input_drivers.R
@@ -1,0 +1,64 @@
+#' @title Combine NHD input drivers
+#' 
+#' @description 
+#' Function to combine river-dl input drivers for NHDPlusv2 reaches, including
+#' mean width, reach slope, reach elevation, and meteorological data.
+#' 
+#' @param nhd_flowlines sf object containing NHDPlusv2 flowline reaches. Must
+#' contain columns "comid", "minelevsmo", "maxelevsmo", "slope"
+#' @param prms_inputs data frame containing input drivers for each NHM segment.
+#' Must include columns "segidnat", "seg_elev", "seg_slope", and "seg_width"
+#' @param nhd_nhm_xwalk data frame that specifies how NHDPlusv2 COMIDs map
+#' onto NHM segment identifiers. Must contain columns "COMID", "PRMS_segid",
+#' and "segidnat".
+#'
+#' @returns 
+#' Returns a data frame with one row per COMID in `nhd_flowlines`. Columns
+#' indicate the NHM segment identifiers, the mean width for the NHD reach 
+#' ("est_width_m"), the slope of the NHD reach ("slope"), the length-weighted
+#' NHD slope for the COMIDs that make up each NHM segment ("slope_len_wtd_mean"), 
+#' the length of the NHD reach ("lengthkm"), the min and max NHD reach elevation
+#' ("min_elev_m" and "max_elev_m"), the elevation, slope, and mean width of the 
+#' corresponding NHM segment ("seg_elev", "seg_slope", and "seg_width"), the
+#' maximum NHD reach width among the COMIDs that make up each NHM segment
+#' ("seg_width_max"), and the minimum NHD slope among the COMIDs that make up
+#' each NHM segment ("seg_elev_min").
+#' 
+combine_nhd_input_drivers <- function(nhd_flowlines, prms_inputs, nhd_nhm_xwalk){
+  
+  # Subset NHDPlusv2 flowlines to return the desired attributes, 
+  # including elevation and slope
+  nhd_attributes <- nhd_flowlines %>%
+    sf::st_drop_geometry() %>%
+    # transform elevation from cm to meters
+    mutate(COMID = as.character(comid),
+           min_elev_m = minelevsmo/100, 
+           max_elev_m = maxelevsmo/100,
+           slope = if_else(slope == -9998, NA_real_, slope)) 
+  
+  # Add NHM segment identifier to NHDv2 attributes table
+  nhd_attributes_w_nhm <- nhd_attributes %>%
+    left_join(y = nhd_nhm_xwalk, by = "COMID") %>%
+    rename(subsegid = PRMS_segid)
+  
+  # Format NHDPlusv2 input data.
+  # calculate length-weighted average slope for NHDv2 reaches associated
+  # with each NHM reach. For simplicity, weight by the reach length rather
+  # than another value-added attribute, slopelenkm, which represents the
+  # length over which the NHDv2 attribute slope was computed.
+  nhd_static_inputs <- nhd_attributes_w_nhm %>%
+    group_by(subsegid) %>%
+    mutate(slope_len_wtd_mean = weighted.mean(x = slope, w = lengthkm, na.rm = TRUE),
+           seg_width_max = max(est_width_m, na.rm = TRUE), 
+           seg_elev_min = min(min_elev_m, na.rm = TRUE)) %>%
+    ungroup() %>%
+    # join select attributes from PRMS-SNTemp
+    left_join(y = prms_inputs, by = "segidnat") %>%
+    select(COMID, segidnat, subsegid, est_width_m, slope, slope_len_wtd_mean, 
+           lengthkm, min_elev_m, max_elev_m, seg_elev, seg_slope, seg_width, seg_width_max,
+           seg_elev_min)
+  
+  return(nhd_static_inputs)
+
+}
+

--- a/2_process/src/subset_nc_to_comid.py
+++ b/2_process/src/subset_nc_to_comid.py
@@ -29,7 +29,10 @@ def subset_nc_to_comids(nc_file, comids):
     comids_not_in_climate = comids[~np.isin(comids, ds.COMID.values)]
     print(comids_not_in_climate)
 
-    # make sure it's just the one that we are expecting
+    # We know of one COMID that has no catchment and so should be included
+    # in `comids_not_in_climate` if passed through in `comids`. Use assert 
+    # statement to make sure we are aware of any others. COMIDs within 
+    # `comids_not_in_climate` will not have matched climate data. 
     if len(comids_not_in_climate) > 0 :
         assert list(comids_not_in_climate) == [4781767]
     ds_comids = ds.sel(COMID=comids_in_climate)

--- a/2_process/src/subset_nc_to_comid.py
+++ b/2_process/src/subset_nc_to_comid.py
@@ -1,0 +1,36 @@
+import xarray as xr
+import numpy as np
+import pandas as pd
+
+
+def ds_to_dataframe_faster(ds):
+    """
+    doing this to try to avoid the multi-index joins
+    """
+    series_list = []
+    for var in ds.data_vars:
+        if "lat" not in var and "lon" not in var:
+            df_var = ds[var].to_pandas().reset_index()
+            df_var_tidy = df_var.melt(id_vars='COMID', value_name=var)
+            series_list.append(df_var_tidy[var])
+    series_list.append(df_var_tidy['COMID'])
+    series_list.append(df_var_tidy['time'])
+    return pd.concat(series_list, axis=1)
+
+
+def subset_nc_to_comids(nc_file, comids):
+    comids = [int(c) for c in comids]
+
+    ds = xr.open_dataset(nc_file)
+
+    # filter out comids that are not in climate drivers (should only be 4781767)
+    comids = np.array(comids)
+    comids_in_climate = comids[np.isin(comids, ds.COMID.values)]
+    comids_not_in_climate = comids[~np.isin(comids, ds.COMID.values)]
+    print(comids_not_in_climate)
+
+    # make sure it's just the one that we are expecting
+    if len(comids_not_in_climate) > 0 :
+        assert list(comids_not_in_climate) == [4781767]
+    ds_comids = ds.sel(COMID=comids_in_climate)
+    return ds_to_dataframe_faster(ds_comids)

--- a/2_process/src/write_data.R
+++ b/2_process/src/write_data.R
@@ -38,7 +38,7 @@ write_df_to_zarr <- function(df, index_cols, out_zarr) {
   # convert to a python (pandas) DataFrame so we have access to the object methods (set_index and to_xarray)
   py_df <- reticulate::r_to_py(df)
   pd <- reticulate::import("pandas")
-  #py_df[["date"]] = pd$to_datetime(py_df$date)
+  py_df[["date"]] = pd$to_datetime(py_df$date)
   py_df[["COMID"]] = py_df$COMID$astype("str")
   
   

--- a/_targets.R
+++ b/_targets.R
@@ -16,6 +16,9 @@ source("2_process.R")
 GFv1_NHDv2_xwalk_url <- paste0("https://raw.githubusercontent.com/USGS-R/drb-network-prep/",
                                "3637931f5a17469a4234eaed3d20ed44ba45958d",
                                "/2_process/out/GFv1_NHDv2_xwalk.csv")
+GFv1_NHDv2_xwalk_dendritic_url <- paste0("https://raw.githubusercontent.com/USGS-R/drb-network-prep/",
+                                         "3637931f5a17469a4234eaed3d20ed44ba45958d",
+                                         "/2_process/out/GFv1_NHDv2_xwalk_dendritic.csv")
 
 
 ## nhd parent id 

--- a/_targets.R
+++ b/_targets.R
@@ -25,9 +25,10 @@ GFv1_NHDv2_xwalk_dendritic_url <- paste0("https://raw.githubusercontent.com/USGS
 # pulled from https://www.sciencebase.gov/catalog/item/5728d6ace4b0b13d3918a992
 nhd_statsgo_parent_sbid <- '5728d6ace4b0b13d3918a992'
 
-## Depth to bedrock data source
-## original source: http://globalchange.bnu.edu.cn/research/dtb.jsp#download (required form submission to obtain)
-## Clipped drb version already stored in Caldera 1_fetch/in. To successfully run this pipeline, this data must be manually copied locally to 1_fetch/in 
+## Depth to bedrock data source (required form submission to obtain)
+## original source: http://globalchange.bnu.edu.cn/research/dtb.jsp#download 
+## To successfully run this pipeline, this data must be manually copied locally to 
+## 1_fetch/in. Clipped drb version already stored in 1_fetch/in on caldera. 
 Shangguan_dtb_cm_250m_clip_path <- '1_fetch/in/Shangguan_dtb_cm_250m_clip/w001001.adf'
 
 # Return the complete list of targets


### PR DESCRIPTION
This PR adds meteorological data to the NHD-scale input drivers. 

The gridmet data (`drb_climate_2022_06_14.nc`) is aggregated to each of the NHDPlusv2 catchments in the DRB and is stored on tallgrass. Right now, the code assumes you've copied that netcdf file into the `1_fetch/in` directory. The dynamic climate drivers are joined with the static input drivers in `p2_input_drivers_nhd` and saved to a zarr file in `p2_input_drivers_nhd_zarr`. These targets are both fairly large, as we're combining 40+ years of climate data across the 3,182 NHDPlusv2 "mainstem" reaches that both 1) have catchments and 2) intersect the NHM segments. I appreciate any thoughts you have on formatting for input to river-dl, including whether there are columns we should omit from `p2_input_drivers_nhd` before saving the output. 

```r
> tar_load(p2_input_drivers_nhd)
> dim(p2_input_drivers_nhd)
[1] 50495158       23
> head(p2_input_drivers_nhd)
# A tibble: 6 x 23
  COMID   segidnat subsegid est_width_m   slope slope_len_wtd_mean lengthkm min_elev_m max_elev_m seg_elev seg_slope seg_width seg_width_max seg_elev_min
  <chr>   <chr>    <chr>          <dbl>   <dbl>              <dbl>    <dbl>      <dbl>      <dbl>    <dbl>     <dbl>     <dbl>         <dbl>        <dbl>
1 1748535 1435     1_1             5.53 0.00263            0.00263     13.6       442.       477.     455.   0.00274      18.2          5.53         442.
2 1748535 1435     1_1             5.53 0.00263            0.00263     13.6       442.       477.     455.   0.00274      18.2          5.53         442.
3 1748535 1435     1_1             5.53 0.00263            0.00263     13.6       442.       477.     455.   0.00274      18.2          5.53         442.
4 1748535 1435     1_1             5.53 0.00263            0.00263     13.6       442.       477.     455.   0.00274      18.2          5.53         442.
5 1748535 1435     1_1             5.53 0.00263            0.00263     13.6       442.       477.     455.   0.00274      18.2          5.53         442.
6 1748535 1435     1_1             5.53 0.00263            0.00263     13.6       442.       477.     455.   0.00274      18.2          5.53         442.
# ... with 9 more variables: time <dttm>, tmmx <dbl>, tmmn <dbl>, pr <dbl>, srad <dbl>, vs <dbl>, rmax <dbl>, rmin <dbl>, sph <dbl>
>
```

Closes #17 