### PR TITLE
Make width attribute comparable between NHD and NHM-scales

### DIFF
--- a/2_process.R
+++ b/2_process.R
@@ -177,6 +177,11 @@ p2_targets_list <- list(
   ),
   
   # Format NHM-scale attributes, including empirical width
+  # TODO: the NHM attributes table below includes 458 rows because subsegid 287_1
+  # (which corresponds with COMID 4188275) does not have a width estimate. This 
+  # segment is functionally omitted in p2_dendritic_nhd_reaches_along_NHM_w_cats
+  # because it doesn't have an NHD catchment area and therefore does not have
+  # meteorological driver data either. 
   tar_target(
     p2_static_inputs_nhm_formatted,
     p2_static_input_drivers_nhd_formatted %>%

--- a/2_process.R
+++ b/2_process.R
@@ -26,7 +26,7 @@ p2_targets_list <- list(
                        sites = p1_drb_temp_sites_sf)
   ),
   
-  # ## Dissolving all reaches to prms scale (joining with xwalk table to do this)
+  # Dissolve all reaches to NHM scale (joining with xwalk table to do this)
   tar_target(p2_buffered_nhd_reaches_along_nhm,
              p1_nhd_reaches_along_NHM %>% 
                mutate(COMID = as.character(comid)) %>%
@@ -34,17 +34,20 @@ p2_targets_list <- list(
                          p1_drb_comids_all_tribs %>%
                            mutate(COMID = as.character(COMID)), 
                          by = 'COMID') %>%
-               st_make_valid() %>% 
+               sf::st_make_valid() %>% 
                # Dissolving by PRMS segid
                group_by(PRMS_segid) %>%
                dplyr::summarize(geometry = sf::st_union(geometry)) %>% 
-               st_buffer(., dist = units::set_units(250, m))
+               sf::st_buffer(., dist = units::set_units(250, m))
   ),
   
   # Depth to bedrock processing
-  ## Note: If you do not have Shangguan_dtb_cm_250m_clip_path data, you must grab it from the caldera project folder. 
-  ## Dataset accessible on caldera in project folder sub-dir: 1_fetch/in. scp to your local 1_fetch/in folder in this repo in order to run this piece of pipeline
-  ## original source: http://globalchange.bnu.edu.cn/research/dtb.jsp. Data was clipped to drb before getting added to caldera.
+  ## Note: If you do not have Shangguan_dtb_cm_250m_clip_path data, you must grab 
+  ## it from the caldera project folder. Dataset accessible on caldera in project 
+  ## folder sub-dir: 1_fetch/in. scp to your local 1_fetch/in folder in this repo 
+  ## in order to run this piece of pipeline original source: 
+  ## http://globalchange.bnu.edu.cn/research/dtb.jsp. 
+  ## Data was clipped to drb before getting added to caldera.
   
   # Reach -- depth_to_bedrock data for each nhm reach buffered at 250m  
   tar_target(p2_depth_to_bedrock_reaches_along_nhm,

--- a/2_process.R
+++ b/2_process.R
@@ -80,7 +80,7 @@ p2_targets_list <- list(
   
   # Pull static segment attributes from PRMS SNTemp model driver data
   tar_target(
-    p2_static_input_drivers_prms,
+    p2_static_inputs_prms,
     p1_sntemp_input_output %>%
       group_by(seg_id_nat) %>%
       summarize(seg_elev = unique(seg_elev),
@@ -92,7 +92,7 @@ p2_targets_list <- list(
   
   # Pull dynamic segment attributes from PRMS SNTemp model driver data
   tar_target(
-    p2_dynamic_input_drivers_prms,
+    p2_dynamic_inputs_prms,
     p1_sntemp_input_output %>%
       mutate(segidnat = as.character(seg_id_nat)) %>%
       select(segidnat, date, seginc_potet)
@@ -135,16 +135,16 @@ p2_targets_list <- list(
   # NHDPlusv2 scales (i.e., seg_slope ~ slope_len_wtd_mean; seg_elev ~ seg_elev_min; 
   # seg_width ~ seg_width_max). 
   tar_target(
-    p2_static_input_drivers_nhd,
+    p2_static_inputs_nhd,
     prepare_nhd_static_inputs(nhd_flowlines = p2_nhd_mainstem_reaches_w_width,
-                              prms_inputs = p2_static_input_drivers_prms,
+                              prms_inputs = p2_static_inputs_prms,
                               nhd_nhm_xwalk = p1_drb_comids_all_tribs)
   ),
   
   # Format NHD-scale static input drivers
   tar_target(
-    p2_static_input_drivers_nhd_formatted,
-    p2_static_input_drivers_nhd %>%
+    p2_static_inputs_nhd_formatted,
+    p2_static_inputs_nhd %>%
       select(COMID, segidnat, subsegid, 
              est_width_m, min_elev_m, slope) %>%
       rename(seg_width_empirical = est_width_m,
@@ -160,9 +160,9 @@ p2_targets_list <- list(
   # days of climate data across each of 3,173 COMIDs = 50,133,400 total rows.
   tar_target(
     p2_input_drivers_nhd,
-    combine_nhd_input_drivers(nhd_static_inputs = p2_static_input_drivers_nhd_formatted, 
+    combine_nhd_input_drivers(nhd_static_inputs = p2_static_inputs_nhd_formatted, 
                               climate_inputs = p2_met_data_nhd_mainstem_reaches,
-                              prms_dynamic_inputs = p2_dynamic_input_drivers_prms,
+                              prms_dynamic_inputs = p2_dynamic_inputs_prms,
                               earliest_date = "1979-01-01",
                               latest_date = "2022-04-04")
   ),
@@ -184,7 +184,7 @@ p2_targets_list <- list(
   # meteorological driver data either. 
   tar_target(
     p2_static_inputs_nhm_formatted,
-    p2_static_input_drivers_nhd_formatted %>%
+    p2_static_inputs_nhd_formatted %>%
       group_by(segidnat, subsegid) %>%
       summarize(seg_width_empirical = max(seg_width_empirical),
                 .groups = "drop")


### PR DESCRIPTION
This PR includes the following code changes to make the width attribute more comparable between the NHDPlusV2 and NHM-scales:

- Create a new variable for NHM segments called `seg_width_empirical` that represents the maximum, empirically-derived width across the COMIDs that comprise each NHM segment. This variable is created within a new target called `p2_static_inputs_nhm_formatted`.
- Modify the name of the width variable for the NHD-scale attributes in `p2_static_inputs_nhd_formatted` to use the same terminology, i.e., `seg_width_empirical`
- Output the NHM widths as a feather file

Here's a plot showing the comparison between the new width attribute at NHD- and NHM-scales:
![width](https://user-images.githubusercontent.com/8785034/188748281-9ec3e731-31d8-40e9-9cdc-b445e80bf76a.png)


Closes #26 