### PR TITLE
Resolve issues with NHM widths file

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -23,7 +23,8 @@ p1_targets_list <- list(
     p1_GFv1_NHDv2_xwalk %>%
       select(PRMS_segid, segidnat, comid_cat) %>% 
       tidyr::separate_rows(comid_cat,sep=";") %>% 
-      rename(COMID = comid_cat)
+      rename(COMID = comid_cat,
+             seg_id_nat = segidnat)
   ),
   
   # Reshape crosswalk table to return all COMIDs that overlap each NHM segment.
@@ -32,7 +33,8 @@ p1_targets_list <- list(
     p1_GFv1_NHDv2_xwalk %>%
       select(PRMS_segid, segidnat, comid_seg) %>% 
       tidyr::separate_rows(comid_seg,sep=";") %>% 
-      rename(COMID = comid_seg)
+      rename(COMID = comid_seg,
+             seg_id_nat = segidnat)
   ),
   
   # Use crosswalk table to fetch all NHDv2 reaches in the DRB. These COMIDs 
@@ -88,7 +90,8 @@ p1_targets_list <- list(
     p1_GFv1_NHDv2_xwalk_dendritic %>%
       select(PRMS_segid, segidnat, comid_seg) %>% 
       tidyr::separate_rows(comid_seg,sep=";") %>% 
-      rename(COMID = comid_seg)
+      rename(COMID = comid_seg,
+             seg_id_nat = segidnat)
   ),
   
   # Use crosswalk table to fetch just the dendritic NHDv2 reaches that overlap

--- a/2_process.R
+++ b/2_process.R
@@ -90,16 +90,16 @@ p2_targets_list <- list(
       summarize(seg_elev = unique(seg_elev),
                 seg_slope = unique(seg_slope),
                 seg_width = mean(seg_width, na.rm = TRUE)) %>%
-      mutate(segidnat = as.character(seg_id_nat)) %>%
-      select(segidnat, seg_elev, seg_slope, seg_width)
+      mutate(seg_id_nat = as.character(seg_id_nat)) %>%
+      select(seg_id_nat, seg_elev, seg_slope, seg_width)
   ),
   
   # Pull dynamic segment attributes from PRMS SNTemp model driver data
   tar_target(
     p2_dynamic_inputs_prms,
     p1_sntemp_input_output %>%
-      mutate(segidnat = as.character(seg_id_nat)) %>%
-      select(segidnat, date, seginc_potet)
+      mutate(seg_id_nat = as.character(seg_id_nat)) %>%
+      select(seg_id_nat, date, seginc_potet)
   ),
   
   # Subset the DRB meteorological data to only include the NHDPlusv2 catchments 
@@ -149,11 +149,12 @@ p2_targets_list <- list(
   tar_target(
     p2_static_inputs_nhd_formatted,
     p2_static_inputs_nhd %>%
-      select(COMID, segidnat, subsegid, 
+      select(COMID, seg_id_nat, subsegid, 
              est_width_m, min_elev_m, slope) %>%
       rename(seg_width_empirical = est_width_m,
              seg_elev = min_elev_m,
-             seg_slope = slope)
+             seg_slope = slope,
+             seg_id_nat = seg_id_nat)
   ),
   
   # Combine NHD-scale static input drivers with dynamic climate drivers. 
@@ -189,9 +190,10 @@ p2_targets_list <- list(
   tar_target(
     p2_static_inputs_nhm_formatted,
     p2_static_inputs_nhd_formatted %>%
-      group_by(segidnat, subsegid) %>%
+      group_by(seg_id_nat, subsegid) %>%
       summarize(seg_width_empirical = max(seg_width_empirical),
-                .groups = "drop")
+                .groups = "drop") %>%
+      mutate(seg_id_nat = as.integer(seg_id_nat))
   ),
   
   # Save a feather file that contains the formatted NHM-scale attributes

--- a/2_process.R
+++ b/2_process.R
@@ -186,11 +186,15 @@ p2_targets_list <- list(
   # (which corresponds with COMID 4188275) does not have a width estimate. This 
   # segment is functionally omitted in p2_dendritic_nhd_reaches_along_NHM_w_cats
   # because it doesn't have an NHD catchment area and therefore does not have
-  # meteorological driver data either. 
+  # meteorological driver data either. In addition, seg_id_nat's 1437, 1442, and
+  # 1485 each have two subsegid's attached to one seg_id_nat (e.g. 3_1 and 3_2 in
+  # the case of seg_id_nat 1437). Since we only consider the seg_id_nat values when
+  # running river-dl, here we assume that the subsegments have the same width value, 
+  # which is equal to the maximum width between the two contributing subsegid's. 
   tar_target(
     p2_static_inputs_nhm_formatted,
     p2_static_inputs_nhd_formatted %>%
-      group_by(seg_id_nat, subsegid) %>%
+      group_by(seg_id_nat) %>%
       summarize(seg_width_empirical = max(seg_width_empirical),
                 .groups = "drop") %>%
       mutate(seg_id_nat = as.integer(seg_id_nat))


### PR DESCRIPTION
This PR includes the following code changes to resolve remaining issues with the NHM attributes feather file, which currently only contains the "empirical" NHM widths:

- Edits all column names to use `seg_id_nat`
- Format `seg_id_nat` as an integer in `p2_static_inputs_nhm_formatted` and `p2_input_drivers_nhd`, which get saved to the feather and zarr files, respectively.
- Estimate width for `seg_id_nat == 1721`. This segment was missing from `p2_static_inputs_nhm_formatted` because the segment does not have a corresponding NHDv2 catchment (and so does not have meteorological data). We opted to go ahead and estimate width for this segment. 
- For seg_id_nat's with more than one subseg_id, use just one width value for each `seg_id_nat`

Closes #33 