### PR TITLE
Process UPSTREAM ("TOT") NHDv2 attributes to NHM-scale

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -291,7 +291,8 @@ p1_targets_list <- list(
   ),
   
   # load in Soller et al. 2009's surficial material dataset
-  tar_target(p1_soller_surficial_mat_zip,
+  tar_target(
+    p1_soller_surficial_mat_zip,
              download_file("https://pubs.usgs.gov/ds/425/USGS_DS_425_SHAPES.zip",
                           fileout = "1_fetch/out/USGS_DS_425_SHAPES.zip", 
                           mode = "wb", quiet = TRUE),

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -38,6 +38,17 @@ p1_targets_list <- list(
              seg_id_nat = segidnat)
   ),
   
+  # Reshape crosswalk table to return all COMIDs that represent the downstream
+  # end of each NHM segment.
+  tar_target(
+    p1_drb_comids_down,
+    p1_GFv1_NHDv2_xwalk %>%
+      select(PRMS_segid, segidnat, comid_down) %>% 
+      tidyr::separate_rows(comid_down,sep=";") %>% 
+      rename(COMID = comid_down,
+             seg_id_nat = segidnat)    
+  ),
+  
   # Use crosswalk table to fetch all NHDv2 reaches in the DRB. These COMIDs 
   # should be used for preparing feature data, including aggregating feature 
   # values from the NHD-scale to the NHM-scale and/or for deriving feature 

--- a/2_process.R
+++ b/2_process.R
@@ -59,23 +59,24 @@ p2_targets_list <- list(
   
   # Create buffer sf object of nhm reaches
   # Use xwalk nhd reaches along nhm and Dissolve all reaches to NHM scale
-  tar_target(p2_buffered_nhm_reaches,
-             ## Join with xwalk table to get PRMS_segids for nhm network
-             p1_nhd_reaches_along_NHM %>% 
-               mutate(COMID = as.character(comid)) %>%
-               left_join(.,
-                         p1_drb_comids_all_tribs %>%
-                           mutate(COMID = as.character(COMID)), 
-                         by = 'COMID') %>%
-               sf::st_make_valid() %>% 
-               ## Dissolving by PRMS segid - old nrow = 3229, new nrow = 459 
-               group_by(PRMS_segid) %>%
-               dplyr::summarize(geometry = sf::st_union(geometry)) %>% 
-               ## Buffer reach segments to 250 
-               sf::st_buffer(.,dist = units::set_units(250, m)) %>% 
-               ## creating new col with area of buffer - useful for downstream targets that uses buffered reaches
-               mutate(total_reach_buffer_area_km2 = units::set_units(st_area(.), km^2)) %>% 
-               relocate(geometry, .after = last_col())
+  tar_target(
+    p2_buffered_nhm_reaches,
+    ## Join with xwalk table to get PRMS_segids for nhm network
+    p1_nhd_reaches_along_NHM %>% 
+      mutate(COMID = as.character(comid)) %>%
+      left_join(.,
+                p1_drb_comids_all_tribs %>%
+                  mutate(COMID = as.character(COMID)),
+                by = 'COMID') %>%
+      sf::st_make_valid() %>% 
+      ## Dissolving by PRMS segid - old nrow = 3229, new nrow = 459 
+      group_by(PRMS_segid) %>%
+      dplyr::summarize(geometry = sf::st_union(geometry)) %>% 
+      ## Buffer reach segments to 250 
+      sf::st_buffer(.,dist = units::set_units(250, m)) %>% 
+      ## creating new col with area of buffer - useful for downstream targets that uses buffered reaches
+      mutate(total_reach_buffer_area_km2 = units::set_units(st_area(.), km^2)) %>% 
+      relocate(geometry, .after = last_col())
   ),
   
   # Depth to bedrock processing

--- a/2_process.R
+++ b/2_process.R
@@ -121,11 +121,12 @@ p2_targets_list <- list(
     ),
   
   # Process Wieczorek NHDPlusv2 attributes referenced to cumulative upstream
-  # area; returns object target of class "list". Note that list elements for 
-  # CAT_PPT and ACC_PPT (if "TOT" is selected below) will only contain the 
-  # PRMS_segid column and so will functionally be omitted when  
-  # creating the `p2_nhdv2_attr` target below. We are using the "TOT" columns
-  # to represent the cumulative upstream attribute values rather than "ACC".
+  # area; returns object target of class "list". 
+  # We are using the "TOT" columns to represent the cumulative upstream
+  # attribute values rather than "ACC".
+  # Note that list elements for CAT_PPT and ACC_PPT (if "TOT" is selected below)
+  # will only contain the PRMS_segid column and so will functionally be omitted when  
+  # creating the `p2_nhdv2_attr` target below. 
   tar_target(
     p2_nhdv2_attr_upstream,
     process_cumulative_nhdv2_attr(file_path = p1_sb_attributes_downloaded_csvs,

--- a/2_process.R
+++ b/2_process.R
@@ -122,11 +122,13 @@ p2_targets_list <- list(
   
   # Process Wieczorek NHDPlusv2 attributes referenced to cumulative upstream
   # area; returns object target of class "list". 
-  # We are using the "TOT" columns to represent the cumulative upstream
-  # attribute values rather than "ACC".
-  # Note that list elements for CAT_PPT and ACC_PPT (if "TOT" is selected below)
-  # will only contain the PRMS_segid column and so will functionally be omitted when  
-  # creating the `p2_nhdv2_attr` target below. 
+  # We are using the "TOT" (total cumulative drainage area) columns in the 
+  # Wieczorek attribute data files to represent the cumulative upstream
+  # attribute values rather than "ACC" (divergence-routed accumulate values). 
+  # Note that if "TOT" is selected below, list elements for CAT_PPT 
+  # (catchment-scale precip) and ACC_PPT (watershed-accumulated precip) will 
+  # only contain the PRMS_segid column and so will functionally be omitted 
+  # when creating the `p2_nhdv2_attr` target below. 
   tar_target(
     p2_nhdv2_attr_upstream,
     process_cumulative_nhdv2_attr(file_path = p1_sb_attributes_downloaded_csvs,

--- a/2_process.R
+++ b/2_process.R
@@ -5,6 +5,7 @@ source("2_process/src/write_data.R")
 source("2_process/src/combine_nhd_input_drivers.R")
 source("2_process/src/munge_split_temp_dat.R")
 source("2_process/src/coarse_stratified_sediment_processing.R")
+source("2_process/src/process_nhdv2_attr.R")
 
 p2_targets_list <- list(
 
@@ -117,6 +118,21 @@ p2_targets_list <- list(
                               coarse_sediments_area_sf = p1_soller_coarse_sediment_drb_sf,
                               prms_col = 'PRMS_segid')
     ),
+  
+  # Process Wieczorek NHDPlusv2 attributes referenced to cumulative upstream
+  # area; returns object target of class "list". Note that list elements for 
+  # CAT_PPT and ACC_PPT (if "TOT" is selected below) will only contain the 
+  # PRMS_segid column and so will functionally be omitted when  
+  # creating the `p2_nhdv2_attr` target below. We are using the "TOT" columns
+  # to represent the cumulative upstream attribute values rather than "ACC".
+  tar_target(
+    p2_nhdv2_attr_upstream,
+    process_cumulative_nhdv2_attr(file_path = p1_sb_attributes_downloaded_csvs,
+                                  segs_w_comids = p1_drb_comids_down,
+                                  cols = c("TOT")),
+    pattern = map(p1_sb_attributes_downloaded_csvs),
+    iteration = "list"
+  ),
   
   # Estimate mean width for each "mainstem" NHDv2 reach. 
   # Note that one NHM segment, segidnat 1721 (subsegid 287_1) is not included

--- a/2_process/src/process_nhdv2_attr.R
+++ b/2_process/src/process_nhdv2_attr.R
@@ -1,0 +1,70 @@
+#' @title Process NHDPlusv2 attributes for cumulative upstream watershed
+#' 
+#' @description 
+#' Function to read in downloaded NHDv2 attribute data and join with river segment ID's.
+#' 
+#' @details This function was pulled and modified from the inland salinity ml project:
+#' https://github.com/USGS-R/drb-inland-salinity-ml/blob/main/2_process/src/process_nhdv2_attr.R
+#'
+#' @param file_path file path of downloaded NHDv2 attribute data table, including file extension
+#' @param segs_w_comids data frame containing the PRMS segment ids and the comids of interest
+#' segs_w_comids must contain variables PRMS_segid and COMID
+#' @param cols character string indicating which columns to retain from downloaded attribute data; 
+#' cols can take values "ACC" or "TOT"
+#'
+#' @value A data frame containing PRMS_id and columns representing the NHDv2 attribute data referenced to the 
+#' cumulative upstream watershed.
+#' 
+process_cumulative_nhdv2_attr <- function(file_path,segs_w_comids,cols){
+
+
+  message(file_path)
+  # Read in downloaded data 
+  # only specify col_type for COMID since cols will differ for each downloaded data file
+  dat <- read_csv(file_path, col_types = cols(COMID = "c"), show_col_types = FALSE)
+  
+  # For PPT data we want to return the long-term (1971-2000) monthly averages 
+  # instead of the monthly values for each year
+  # LAUREN: Commenting out the two lines below that are used in inland salinity but
+  # not for our groundwater data prep.
+  #if(grepl("PPT_TOT",file_path)|grepl("PPT_ACC",file_path)){
+  #  message("Calculating long-term monthly average precipitation from annual data")
+  #  dat <- calc_monthly_avg_ppt(dat)
+  #}
+  
+  # For NADP data we want to return the long-term (1984-2014) average 
+  # instead of annual values for each constituent
+  # LAUREN: Commenting out the two lines below that are used in inland salinity
+  # but not for our groundwater data prep.
+  #if(grepl("NADP",file_path)){
+  #  message("Calculating long-term average NADP from annual data")
+  #  dat <- calc_avg_NADP(dat)
+  #}
+    
+  # Process downloaded data
+  dat_proc <- dat %>%
+    # retain desired columns ('ACC' or 'TOT')
+    select(c(COMID, starts_with(cols))) %>%
+    # join data to {segs_w_comids} data frame by COMID
+    right_join(., segs_w_comids,by = "COMID") %>%
+    relocate("PRMS_segid", .before = "COMID") %>%
+    relocate("seg_id_nat", .before = "COMID") %>%
+    select(-COMID)
+  
+  # Flag columns with undesired flag values (e.g. -9999)
+  flag_cols <- dat_proc %>%
+    select(where(function(x) -9999 %in% x)) %>% 
+    names()
+  
+  # For columns with undesired flag values, replace -9999 with NA, else use existing value
+  dat_proc_out <- dat_proc %>%
+    mutate(across(all_of(flag_cols), 
+                  ~case_when(. == -9999 ~ NA_real_, 
+                             TRUE ~ as.numeric(.))))
+
+  return(dat_proc_out)
+  
+}
+
+
+

--- a/2_process/src/process_nhdv2_attr.R
+++ b/2_process/src/process_nhdv2_attr.R
@@ -17,25 +17,25 @@
 #' 
 process_cumulative_nhdv2_attr <- function(file_path,segs_w_comids,cols){
 
-
   message(file_path)
   # Read in downloaded data 
   # only specify col_type for COMID since cols will differ for each downloaded data file
   dat <- read_csv(file_path, col_types = cols(COMID = "c"), show_col_types = FALSE)
   
-  # For PPT data we want to return the long-term (1971-2000) monthly averages 
-  # instead of the monthly values for each year
+
   # LAUREN: Commenting out the two lines below that are used in inland salinity but
   # not for our groundwater data prep.
+  # For PPT data we want to return the long-term (1971-2000) monthly averages 
+  # instead of the monthly values for each year
   #if(grepl("PPT_TOT",file_path)|grepl("PPT_ACC",file_path)){
   #  message("Calculating long-term monthly average precipitation from annual data")
   #  dat <- calc_monthly_avg_ppt(dat)
   #}
   
-  # For NADP data we want to return the long-term (1984-2014) average 
-  # instead of annual values for each constituent
   # LAUREN: Commenting out the two lines below that are used in inland salinity
   # but not for our groundwater data prep.
+  # For NADP data we want to return the long-term (1984-2014) average 
+  # instead of annual values for each constituent
   #if(grepl("NADP",file_path)){
   #  message("Calculating long-term average NADP from annual data")
   #  dat <- calc_avg_NADP(dat)


### PR DESCRIPTION
This PR addresses the first task in issue #40, and adds two targets and one function. The first target, `p1_drb_comids_down`, is another crosswalk-related target and gives us only the COMIDs that represent the downstream terminus of an NHM segment. We need these COMIDs in order to subset the attribute datasets, which is what the function `process_cumulative_nhdv2_attr()` does. Note that `process_cumulative_nhdv2_attr()` is pulled straight from the inland salinity repo. 

The output of `p2_nhdv2_attr_upstream` is a list, where each data frame represents the subsetted attribute values with one row per "downstream" COMID in the DRB. Here's what the base flow index (BFI) dataset looks like:


```r
> tar_load(p2_nhdv2_attr_upstream)
> class(p2_nhdv2_attr_upstream)
[1] "list"
> dim(p2_nhdv2_attr_upstream[[1]])
[1] 459   3
> head(p2_nhdv2_attr_upstream[[1]])
# A tibble: 6 x 3
  PRMS_segid seg_id_nat TOT_BFI
  <chr>      <chr>        <dbl>
1 1_1        1435          39.7
2 3_1        1437          41.2
3 2_1        1436          43.4
4 8_1        1442          46.7
5 3_2        1437          43.1
6 4_1        1438          43.2
>
``` 

@msleckman I'm again chunking up #40 into a couple PR's to keep each PR more manageable. The steps involved in this task of gathering the upstream/TOT attribute values are relatively straightforward compared to the CAT-level processing steps, so I think this only requires a very high-level review from you (max ~15-20 minutes). Do you think you'd be able to take a look by this coming Tuesday (9/27)? 