### PR TITLE
Combine processed NHDv2 attributes

### DIFF
--- a/2_process.R
+++ b/2_process.R
@@ -152,6 +152,13 @@ p2_targets_list <- list(
     iteration = "list"
   ),
   
+  # Create combined NHDv2 attribute data frame that includes both the cumulative 
+  # upstream and catchment-scale values that have been aggregated to the NHM scale.
+  tar_target(
+    p2_nhdv2_attr,
+    create_nhdv2_attr_table(p2_nhdv2_attr_upstream, p2_nhdv2_attr_catchment)
+  ),
+  
   # Estimate mean width for each "mainstem" NHDv2 reach. 
   # Note that one NHM segment, segidnat 1721 (subsegid 287_1) is not included
   # in the dendritic nhd reaches w cats data frame because the only COMID that


### PR DESCRIPTION
This PR addresses the fourth task in issue https://github.com/USGS-R/drb-gw-hw-model-prep/issues/40, and adds one new target. `p2_nhdv2_attr` represents a single data frame with one row per NHM segment that contains the TOT and CAT-level catchment attribute values that have been processed to that segment.

Here is what this target looks like for me:
```r
> tar_load(p2_nhdv2_attr)
> dim(p2_nhdv2_attr)
[1] 459  66
> head(p2_nhdv2_attr)
# A tibble: 6 x 66
  PRMS_segid AREASQKM_PRMS LENGTHKM_PRMS CAT_BFI_area_wtd seg_id_nat TOT_BFI CAT_CONTACT_area_wtd TOT_CONTACT CAT_EWT_area_wtd TOT_EWT
  <chr>              <dbl>         <dbl>            <dbl> <chr>        <dbl>                <dbl>       <dbl>            <dbl>   <dbl>
1 1_1                65.0          13.6              39.7 1435          39.7                 48.0        48.0            -43.2   -43.2
2 10_1                5.47          2.08             43.8 1444          43.7                 16.5        46.6            -69.3   -36.3
3 11_1                5.94          1.82             44.3 1445          43.2                100          47.0            -30.4   -36.2
4 111_1              41.6          10.6              38.5 1545          38.5                 45.1        45.1            -32.9   -32.9
5 112_1             271.          104.               41.9 1546          41.1                 67.5        63.3            -31.9   -30.6
6 113_1              21.1           9.58             43.3 1547          41.2                 56.2        62.9            -27.8   -30.5
# ... with 56 more variables: CAT_RECHG_area_wtd <dbl>, TOT_RECHG <dbl>, CAT_TWI_area_wtd <dbl>, TOT_TWI <dbl>,
#   CAT_OLSON_PERM_area_wtd <dbl>, TOT_OLSON_PERM <dbl>, CAT_IMPV11_area_wtd <dbl>, TOT_IMPV11 <dbl>, CAT_HGA_area_wtd <dbl>, TOT_HGA <dbl>,
#   CAT_SANDAVE_area_wtd <dbl>, CAT_CLAYAVE_area_wtd <dbl>, CAT_SILTAVE_area_wtd <dbl>, TOT_CLAYAVE <dbl>, TOT_SANDAVE <dbl>,
#   TOT_SILTAVE <dbl>, CAT_PERMAVE_area_wtd <dbl>, CAT_WTDEP_area_wtd <dbl>, CAT_KFACT_area_wtd <dbl>, CAT_KFACT_UP_area_wtd <dbl>,
#   CAT_NO10AVE_area_wtd <dbl>, CAT_NO4AVE_area_wtd <dbl>, CAT_ROCKDEP_area_wtd <dbl>, TOT_KFACT <dbl>, TOT_KFACT_UP <dbl>,
#   TOT_NO10AVE <dbl>, TOT_NO4AVE <dbl>, TOT_PERMAVE <dbl>, TOT_ROCKDEP <dbl>, TOT_WTDEP <dbl>, CAT_PPT7100_ANN_area_wtd <dbl>,
#   TOT_PPT7100_ANN <dbl>, CAT_MIRAD_2012_area_wtd <dbl>, TOT_MIRAD_2012 <dbl>, CAT_BEDPERM_1_area_wtd <dbl>, ...
>
```

This target and the function `create_nhdv2_attr_table` are copied from our inland salinity repo, so I think a code review can be high-level and mainly for awareness, i.e. how this PR fits in our pipeline. 
