### PR TITLE
Fetch and process channel confinement data

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -327,7 +327,7 @@ p1_targets_list <- list(
       )
   ),
   
-  # Fetch McManamay and DeRolph stream classification dataset that contains 
+  # Download McManamay and DeRolph stream classification dataset that contains 
   # channel confinement data for each NHDPlusV2 flowline within CONUS:
   # https://doi.org/10.6084/m9.figshare.c.4233740.v1 (accompanying paper in
   # Scientific Data, https://doi.org/10.1038/sdata.2019.17).
@@ -357,7 +357,35 @@ p1_targets_list <- list(
   tar_target(
     p1_confinement_mcmanamay,
     read_csv(p1_confinement_mcmanamay_csv, show_col_types = FALSE)
+  ),
+  
+  # Download DRB geomorphometry dataset, collected using the FACET model 
+  # (Hopkins et al. 2020, Chesapeake and Delaware Combined Files; 
+  # https://doi.org/10.5066/P9RQJPT1).
+  tar_target(
+    p1_facet_zip,
+    download_sb_file(sb_id = "5e4d6d68e4b0ff554f6db504",
+                     file_name = "ChesapeakeDelaware_FACEToutput.zip",
+                     out_dir = "1_fetch/out/drb_facet"),
+    format = "file"
+  ),
+  
+  # Unzip DRB geomorphometry dataset and identify geomorphic metrics file.
+  tar_target(
+    p1_facet_geomorph_metrics_csv,
+    {
+      file_names <- unzip(zipfile = p1_facet_zip, 
+                          exdir = "1_fetch/out/drb_facet", 
+                          overwrite = TRUE)
+      grep("CDW_FACET_MetricsAll_Reach.csv",file_names, value = TRUE, ignore.case = TRUE)
+    }, 
+    format = "file"
+  ),
+  
+  # Read in DRB geomorphic metrics data from FACET.
+  tar_target(
+    p1_facet_geomorph_metrics,
+    read_csv(p1_facet_geomorph_metrics_csv, show_col_types = FALSE)
   )
-
   
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -397,6 +397,7 @@ p1_targets_list <- list(
     {
       network_file <- grep("CDW_FACET_Network.shp$", p1_facet_files, value = TRUE)
       sf::st_read(network_file, quiet = TRUE) %>%
+        filter(!sf::st_is_empty(.)) %>%
         sf::st_transform(., crs = crs) %>%
         mutate(HUC4 = stringr::str_sub(HUCID, 1, 4)) %>%
         filter(HUC4 == "0204") %>%

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -175,6 +175,22 @@ p1_targets_list <- list(
     read_csv(p1_drb_temp_obs_csv, col_types = list(seg_id_nat = "c"))
   ),
   
+  # Download DRB distance matrix from ScienceBase:
+  # https://www.sciencebase.gov/catalog/item/623e5587d34e915b67d83806
+  tar_target(
+    p1_nhm_distance_matrix_csv,
+    download_sb_file(sb_id = "623e5587d34e915b67d83806",
+                     file_name = "distance_matrix_drb.csv",
+                     out_dir = "1_fetch/out"),
+    format = "file"
+  ),
+  
+  # Read in DRB distance matrix:
+  tar_target(
+    p1_nhm_distance_matrix,
+    read_csv(p1_nhm_distance_matrix_csv, show_col_types = FALSE)
+  ),
+  
   # Download PRMS-SNTemp model driver data from ScienceBase:
   # https://www.sciencebase.gov/catalog/item/623e5587d34e915b67d83806
   tar_target(

--- a/2_process.R
+++ b/2_process.R
@@ -122,12 +122,19 @@ p2_targets_list <- list(
     ),
   
   # Process McManamay channel confinement dataset, including reaggregating
-  # from NHDPlusv2 to NHM.
+  # from NHDPlusv2 to NHM. Use width values estimated from empirical regression
+  # equation combined with floodplain width values from McManamay and DeRolph (2018)
+  # when estimating channel confinement.
   tar_target(
     p2_confinement_mcmanamay,
     aggregate_mcmanamay_confinement(confinement_data = p1_confinement_mcmanamay, 
                                     nhd_nhm_xwalk = p1_drb_comids_segs, 
                                     force_min_width_m = 1,
+                                    preferred_width_df = p2_nhd_mainstem_reaches_w_width %>%
+                                      sf::st_drop_geometry() %>%
+                                      mutate(COMID = as.character(comid)) %>%
+                                      select(COMID, est_width_m) %>%
+                                      rename(width_m = est_width_m),
                                     network = "nhm",
                                     nhm_identifier_col = "seg_id_nat")
   ),

--- a/2_process.R
+++ b/2_process.R
@@ -134,6 +134,19 @@ p2_targets_list <- list(
                                     nhm_identifier_col = "seg_id_nat")
   ),
   
+  # The processed McManamay channel confinement data are missing confinement
+  # values for 17 NHM segments. The objective of this target is to impute
+  # the NA values with confinement estimates from the nearest upstream 
+  # segment with a non-NA confinement value. 
+  tar_target(
+    p2_confinement_mcmanamay_filled,
+    refine_from_neighbors(attr_df = p2_confinement_mcmanamay, 
+                          nhm_identifier_col = "seg_id_nat",
+                          attr_name = "confinement_calc_mcmanamay",
+                          reach_distances = p1_nhm_distance_matrix,
+                          neighbors = "nearest")
+  ),
+  
   # Pull centroid of each reach within FACET stream network.
   # [Lauren] This target took ~1.3 hours to build on my local machine. It
   # takes a long time because the FACET stream network is so dense. We 
@@ -161,6 +174,19 @@ p2_targets_list <- list(
                                 nhd_nhm_xwalk = p1_drb_comids_segs,
                                 network = "nhm",
                                 nhm_identifier_col = "seg_id_nat")
+  ),
+  
+  # The processed FACET channel confinement data are missing confinement
+  # values for 93 NHM segments. The objective of this target is to impute
+  # the NA values with confinement estimates from the nearest upstream 
+  # segment with a non-NA confinement value. 
+  tar_target(
+    p2_confinement_facet_filled,
+    refine_from_neighbors(attr_df = p2_confinement_facet, 
+                          nhm_identifier_col = "seg_id_nat",
+                          attr_name = "confinement_calc_facet",
+                          reach_distances = p1_nhm_distance_matrix,
+                          neighbors = "nearest")
   ),
   
   # Process Wieczorek NHDPlusv2 attributes referenced to cumulative upstream

--- a/2_process.R
+++ b/2_process.R
@@ -127,6 +127,7 @@ p2_targets_list <- list(
     p2_confinement_mcmanamay,
     aggregate_mcmanamay_confinement(confinement_data = p1_confinement_mcmanamay, 
                                     nhd_nhm_xwalk = p1_drb_comids_segs, 
+                                    force_min_width_m = 1,
                                     network = "nhm",
                                     nhm_identifier_col = "seg_id_nat")
   ),

--- a/2_process.R
+++ b/2_process.R
@@ -5,6 +5,7 @@ source("2_process/src/write_data.R")
 source("2_process/src/combine_nhd_input_drivers.R")
 source("2_process/src/munge_split_temp_dat.R")
 source("2_process/src/coarse_stratified_sediment_processing.R")
+source("2_process/src/process_channel_confinement.R")
 source("2_process/src/process_nhdv2_attr.R")
 
 p2_targets_list <- list(
@@ -119,6 +120,15 @@ p2_targets_list <- list(
                               coarse_sediments_area_sf = p1_soller_coarse_sediment_drb_sf,
                               prms_col = 'PRMS_segid')
     ),
+  
+  # Process McManamay channel confinement dataset, including reaggregating
+  # from NHDPlusv2 to NHM.
+  tar_target(
+    p2_confinement_mcmanamay,
+    aggregate_mcmanamay_confinement(confinement_data = p1_confinement_mcmanamay, 
+                                    nhd_nhm_xwalk = p1_drb_comids_segs, 
+                                    network = "nhm")
+  ),
   
   # Process Wieczorek NHDPlusv2 attributes referenced to cumulative upstream
   # area; returns object target of class "list". 

--- a/2_process.R
+++ b/2_process.R
@@ -130,6 +130,25 @@ p2_targets_list <- list(
                                     network = "nhm")
   ),
   
+  # Process FACET DRB geomorphometry dataset by first spatially joining the FACET
+  # stream network with the NHDPlusv2 catchments. For each NHDPlusv2 catchment,
+  # subset the FACET segment with the largest shreve magnitude (if multiple with
+  # the same magnitude, break a tie with upstream area). Select columns for mean
+  # channel width (between 5th and 95th percentiles within reach) and floodplain
+  # width as described in https://doi.org/10.1088/1748-9326/ac6e47. If aggregation
+  # to NHM segments is requested, FACET floodplain width and channel width values
+  # for each NHDPlusv2 COMID are summarized as a length-weighted mean before 
+  # calculating channel confinement.
+  tar_target(
+    p2_confinement_facet,
+    calculate_facet_confinement(p1_facet_network, 
+                                facet_width_col = "CW955mean_1D",
+                                facet_floodplain_width_col = "FWmean_1D_FP",
+                                nhd_catchment_polygons = p1_nhd_catchments,
+                                nhd_nhm_xwalk = p1_drb_comids_segs,
+                                network = "nhm")
+  ),
+  
   # Process Wieczorek NHDPlusv2 attributes referenced to cumulative upstream
   # area; returns object target of class "list". 
   # We are using the "TOT" (total cumulative drainage area) columns in the 

--- a/2_process.R
+++ b/2_process.R
@@ -121,20 +121,15 @@ p2_targets_list <- list(
                               prms_col = 'PRMS_segid')
     ),
   
-  # Process McManamay channel confinement dataset, including reaggregating
-  # from NHDPlusv2 to NHM. Use width values estimated from empirical regression
-  # equation combined with floodplain width values from McManamay and DeRolph (2018)
-  # when estimating channel confinement.
+  # Process McManamay channel confinement dataset, including reaggregating from
+  # NHDPlusv2 to NHM. Replace any width values in the McManamay and DeRolph (2018)
+  # dataset that are less than 1m with 1m (the minimum width allowed). See further
+  # discussion in https://github.com/USGS-R/drb-gw-hw-model-prep/issues/41.
   tar_target(
     p2_confinement_mcmanamay,
     aggregate_mcmanamay_confinement(confinement_data = p1_confinement_mcmanamay, 
                                     nhd_nhm_xwalk = p1_drb_comids_segs, 
                                     force_min_width_m = 1,
-                                    preferred_width_df = p2_nhd_mainstem_reaches_w_width %>%
-                                      sf::st_drop_geometry() %>%
-                                      mutate(COMID = as.character(comid)) %>%
-                                      select(COMID, est_width_m) %>%
-                                      rename(width_m = est_width_m),
                                     network = "nhm",
                                     nhm_identifier_col = "seg_id_nat")
   ),

--- a/2_process/src/process_channel_confinement.R
+++ b/2_process/src/process_channel_confinement.R
@@ -47,18 +47,31 @@ aggregate_mcmanamay_confinement <- function(confinement_data, nhd_nhm_xwalk, net
               valley_bottom_length = sum(VBL),
               reach_area = sum(RWA),
               valley_bottom_area = sum(VBA)) %>%
-    ungroup() %>%
+    ungroup()
+  
+  confinement_proc <- confinement_nhm %>%
+    # Back-calculate river width and floodplain width from the values given
+    # (river width area, RWA and reach length, RL; valley bottom area, VBA and
+    # valley bottom length along stream reach, VBL). RL and VBL are in kilometers,
+    # whereas RWA and VBA are in m2. 
+    mutate(river_width_m = reach_area/(reach_length*1000),
+           floodplain_width_m = valley_bottom_area/(valley_bottom_length*1000)) %>%
     mutate(vbl_rl_ratio = valley_bottom_length/reach_length,
            vba_ra_ratio = ifelse((valley_bottom_area == 0 & reach_area == 0), 
                                  0, (valley_bottom_area/reach_area))) %>%
     # Now use McManamay categorization scheme (described in https://doi.org/10.1038/sdata.2019.17)
     # to assign confinement categories, "unconfined," "moderately confined," or "confined."
-    mutate(Confinement_calc = case_when(
+    mutate(Confinement_category_calc = case_when(
       vbl_rl_ratio > 0.50 & vba_ra_ratio > 4 ~ "Unconfined",
       vbl_rl_ratio > 0.50 & vba_ra_ratio < 4 & vba_ra_ratio > 2 ~ "Mod Confined",
       vba_ra_ratio > 4 & vbl_rl_ratio > 0.25 & vbl_rl_ratio < 0.5 ~ "Mod Confined",
       TRUE ~ "Confined"
-    ))
+    )) %>%
+    # McManamay and DeRolph only present confinement classes, but we could also calculate a 
+    # numeric value for confinement based on the information given.
+    mutate(Confinement_calc = if_else(vbl_rl_ratio == 0 & vba_ra_ratio != 0,
+                                      NA_real_,
+                                      vba_ra_ratio/vbl_rl_ratio))
   
   # Return processed confinement dataset depending on the network requested
   if(network == "nhdv2"){

--- a/2_process/src/process_channel_confinement.R
+++ b/2_process/src/process_channel_confinement.R
@@ -1,0 +1,70 @@
+#' @title Process McManamay channel confinement data
+#' 
+#' @description 
+#' Function to process McManamay and DeRolph (2018) channel confinement dataset,
+#' including to aggregate the values from NHDv2 reaches to NHM segments.
+#' 
+#' @param confinement_data data frame containing McManamay channel confinement
+#' data. Must include columns "COMID", "VBL", "RL", "RWA", and "VBA".
+#' @param nhd_nhm_xwalk data frame that specifies how NHDPlusv2 COMIDs map
+#' onto NHM segment identifiers. Must contain columns "COMID", "PRMS_segid",
+#' and "seg_id_nat".
+#' @param network character string indicating the requested resolution of the
+#' channel confinement values. Options include "nhdv2" or "nhm". If "nhm", 
+#' the river and valley bottom lengths and areas will be aggregated to NHM
+#' flowlines and the channel confinement categories will be assigned using
+#' the same criteria as described in the McManamay and DeRolph (2018) Scientific
+#' Data paper: https://doi.org/10.1038/sdata.2019.17.
+#' 
+#' @returns 
+#' Returns a data frame with one row per reach/segment and columns representing
+#' the valley bottom length: river length ratio, the valley bottom area: river
+#' area ratio, and the confinement category that was assigned ("Confinement_calc").
+#' 
+aggregate_mcmanamay_confinement <- function(confinement_data, nhd_nhm_xwalk, network = "nhdv2"){
+  
+  # Check that the value for `network` matches one of two options we expect
+  if(!network %in% c("nhdv2","nhm")){
+    stop(paste0("The network argument accepts 'nhdv2' or 'nhm'. Please check ",
+                "that the requested network matches one of these two options."))
+  }
+  
+  # Subset full confinement dataset to the NHDPlusv2 COMID's of interest
+  confinement_subset <- confinement_data %>%
+    filter(COMID %in% nhd_nhm_xwalk$COMID)
+  
+  # Join subsetted confinement dataset to NHM segment identifiers
+  confinement_w_nhm_segs <- confinement_subset %>%
+    mutate(COMID = as.character(COMID)) %>%
+    left_join(nhd_nhm_xwalk, by = "COMID")
+  
+  # Group data by NHM segment and sum reach length, valley bottom length, 
+  # reach area, and valley bottom area from individual COMIDs that comprise
+  # each NHM segment. 
+  confinement_nhm <- confinement_w_nhm_segs %>%
+    group_by(seg_id_nat) %>%
+    summarize(reach_length = sum(RL),
+              valley_bottom_length = sum(VBL),
+              reach_area = sum(RWA),
+              valley_bottom_area = sum(VBA)) %>%
+    ungroup() %>%
+    mutate(vbl_rl_ratio = valley_bottom_length/reach_length,
+           vba_ra_ratio = ifelse((valley_bottom_area == 0 & reach_area == 0), 
+                                 0, (valley_bottom_area/reach_area))) %>%
+    # Now use McManamay categorization scheme (described in https://doi.org/10.1038/sdata.2019.17)
+    # to assign confinement categories, "unconfined," "moderately confined," or "confined."
+    mutate(Confinement_calc = case_when(
+      vbl_rl_ratio > 0.50 & vba_ra_ratio > 4 ~ "Unconfined",
+      vbl_rl_ratio > 0.50 & vba_ra_ratio < 4 & vba_ra_ratio > 2 ~ "Mod Confined",
+      vba_ra_ratio > 4 & vbl_rl_ratio > 0.25 & vbl_rl_ratio < 0.5 ~ "Mod Confined",
+      TRUE ~ "Confined"
+    ))
+  
+  # Return processed confinement dataset depending on the network requested
+  if(network == "nhdv2"){
+    return(confinement_subset)
+  }else{
+    return(confinement_nhm)
+  }
+  
+}

--- a/_targets.R
+++ b/_targets.R
@@ -3,8 +3,9 @@ library(targets)
 options(tidyverse.quiet = TRUE, timeout = 300)
 tar_option_set(packages = c("raster","sbtools","sf","nhdplusTools", 'purrr', 'terra', 'tidyverse', "arrow", "tidync", "ncdf4", "reticulate")) 
 
-# dir for selected datasets soil characteristics from nhd statsgo
+# dir for selected input datasets
 dir.create("1_fetch/out/nhdv2_attr", showWarnings = FALSE)
+dir.create("1_fetch/out/mcmanamay2018", showWarnings = FALSE)
 
 source("1_fetch.R")
 source("2_process.R")

--- a/_targets.R
+++ b/_targets.R
@@ -6,6 +6,7 @@ tar_option_set(packages = c("raster","sbtools","sf","nhdplusTools", 'purrr', 'te
 # dir for selected input datasets
 dir.create("1_fetch/out/nhdv2_attr", showWarnings = FALSE)
 dir.create("1_fetch/out/mcmanamay2018", showWarnings = FALSE)
+dir.create("1_fetch/out/drb_facet", showWarnings = FALSE)
 
 source("1_fetch.R")
 source("2_process.R")


### PR DESCRIPTION
The code changes here add steps to 1) download two different datasets that contain estimates of floodplain width and river channel width (McManamay and DeRolph 2018; and Hopkins et al. 2020) and 2) calculate channel confinement for each NHDPlusv2 reach and aggregate those values to the NHM segments in the DRB. 

 There are 3 new functions to carry out these steps, including:

-  `aggregate_mcmanamay_confinement()`, which aggregates the NHDv2-scale confinement values derived from McManamay and DeRolph (2018) to the NHM segments.
- `calculate_facet_confinement()`, which calculates NHDv2-scale confinement values from the FACET geomorphic data, and then aggregates those values to the NHM segments.
- `refine_from_neighbors()`, which attempts to impute missing confinement values from either dataset using either the nearest 
"upstream" neighbor, "downstream" neighbor, or "nearest" neighbor that is not `NA`.


For the McManamay and DeRolph data, there are 17 segments with `NA` in `p2_confinement_mcmanamay`, but we are able to fill all of those using the "nearest" non-NA neighbor (0.3 - 9.4 km away):
```r
> tar_load(p2_confinement_mcmanamay_filled)
> dim(p2_confinement_mcmanamay_filled)
[1] 456   7
> p2_confinement_mcmanamay_filled[is.na(p2_confinement_mcmanamay_filled$confinement_calc_mcmanamay),]
# A tibble: 0 x 7
# ... with 7 variables: seg_id_nat <chr>, reach_length_km <dbl>, lengthkm_mcmanamay_is_na <dbl>, prop_reach_w_mcmanamay <dbl>,
#   confinement_calc_mcmanamay <dbl>, flag_mcmanamay <chr>, flag_gaps <chr>
>
```

For the FACET data, there are 93 segments with `NA` in `p2_confinement_facet`. We are able to impute most of those using the "nearest" non-NA neighbor (0.1 - 26.6 km away), but there are still 3 segments that are missing FACET-derived confinement values:

```r
> tar_load(p2_confinement_facet_filled)
> dim(p2_confinement_facet_filled)
[1] 456   7
> p2_confinement_facet_filled[is.na(p2_confinement_facet_filled$confinement_calc_facet),]
# A tibble: 3 x 7
  seg_id_nat lengthkm lengthkm_facet_is_na prop_reach_w_facet confinement_calc_facet flag_facet                                       flag_gaps
  <chr>         <dbl>                <dbl>              <dbl>                  <dbl> <chr>                                            <chr>    
1 4199          10.4                 10.4                   0                     NA Note that <70% of the NHM segment is covered by~ NA       
2 4200           5.30                 5.30                  0                     NA Note that <70% of the NHM segment is covered by~ NA       
3 4231           4.66                 4.66                  0                     NA Note that <70% of the NHM segment is covered by~ NA       
>
```

These three segments are still `NA` because there are no connecting reaches in the DRB network that have FACET data:


![facet_filled](https://user-images.githubusercontent.com/8785034/200376100-5b8238fa-95a3-4a76-b434-4312577cfbea.png)

I'm requesting that @janetrbarclay review the functions in `2_process/src/process_channel_confinement` to make sure these steps reflect what we've discussed in #41. 

@msleckman, I'm tagging you here for awareness. If you want to try building the pipeline with the changes included here, I'd welcome any feedback. But `p2_facet_network_centroid` takes over an hour to build, so it may not be worth the time investment. 




Closes #41 