### PR TITLE
Write attributes to feather file

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -428,6 +428,26 @@ p1_targets_list <- list(
         select(UniqueID, HUC4, geometry) %>%
         left_join(p1_facet_geomorph_metrics, by = "UniqueID")
     }
+  ),
+  
+  # Track outputs from MODFLOW_extraction workflow
+  tar_target(
+    p1_modflow_params_feather,
+    "1_fetch/in/data_zell2020_wrr/MODFLOW_params_NHM_zell2020_wrr_02.feather"
+  ),
+  tar_target(
+    p1_modflow_discharge_feather,
+    "1_fetch/in/data_zell2020_wrr/MODFLOW_Discharge_NHM_zell2020_wrr_02.feather"
+  ),
+  
+  # Read in outputs from MODFLOW_extraction workflow
+  tar_target(
+    p1_modflow_params,
+    arrow::read_feather(p1_modflow_params_feather)
+  ),
+  tar_target(
+    p1_modflow_discharge,
+    arrow::read_feather(p1_modflow_discharge_feather)
   )
   
 )


### PR DESCRIPTION
This PR adds targets to track and read in the outputs from the MODFLOW_extraction workflow; combine the river/catchment attributes into a single data frame in `p2_static_inputs_nhm_combined`; and writes the combined data to a feather file called `'2_process/out/nhm_attributes.feather'`. 

The data contains one row for each `seg_id_nat` and one column for each attribute:
```r
> tar_load(p2_static_inputs_nhm_combined)
> dim(p2_static_inputs_nhm_combined)
[1] 456  92
> names(p2_static_inputs_nhm_combined)
 [1] "seg_id_nat"                  "seg_width_empirical"         "seg_elev"                    "seg_slope"                   "seg_width"                  
 [6] "dtb_weighted_mean_reach"     "dtb_weighted_mean_catchment" "reach_length_km"             "lengthkm_mcmanamay_is_na"    "prop_reach_w_mcmanamay"     
[11] "confinement_calc_mcmanamay"  "flag_mcmanamay"              "flag_gaps_mcmanamay"         "lengthkm"                    "lengthkm_facet_is_na"       
[16] "prop_reach_w_facet"          "confinement_calc_facet"      "flag_facet"                  "flag_gaps_facet"             "AREASQKM_PRMS"              
[21] "LENGTHKM_PRMS"               "CAT_BFI_area_wtd"            "TOT_BFI"                     "CAT_CONTACT_area_wtd"        "TOT_CONTACT"                
[26] "CAT_EWT_area_wtd"            "TOT_EWT"                     "CAT_RECHG_area_wtd"          "TOT_RECHG"                   "CAT_TWI_area_wtd"           
[31] "TOT_TWI"                     "CAT_OLSON_PERM_area_wtd"     "TOT_OLSON_PERM"              "CAT_CNPY11_BUFF100_area_wtd" "TOT_CNPY11_BUFF100"         
[36] "CAT_IMPV11_area_wtd"         "TOT_IMPV11"                  "CAT_HGA_area_wtd"            "TOT_HGA"                     "CAT_SANDAVE_area_wtd"       
[41] "CAT_CLAYAVE_area_wtd"        "CAT_SILTAVE_area_wtd"        "TOT_CLAYAVE"                 "TOT_SANDAVE"                 "TOT_SILTAVE"                
[46] "CAT_PERMAVE_area_wtd"        "CAT_WTDEP_area_wtd"          "CAT_KFACT_area_wtd"          "CAT_KFACT_UP_area_wtd"       "CAT_NO10AVE_area_wtd"       
[51] "CAT_NO4AVE_area_wtd"         "CAT_ROCKDEP_area_wtd"        "TOT_KFACT"                   "TOT_KFACT_UP"                "TOT_NO10AVE"                
[56] "TOT_NO4AVE"                  "TOT_PERMAVE"                 "TOT_ROCKDEP"                 "TOT_WTDEP"                   "CAT_PPT7100_ANN_area_wtd"   
[61] "TOT_PPT7100_ANN"             "CAT_MIRAD_2012_area_wtd"     "TOT_MIRAD_2012"              "CAT_BEDPERM_1_area_wtd"      "CAT_BEDPERM_2_area_wtd"     
[66] "CAT_BEDPERM_3_area_wtd"      "CAT_BEDPERM_4_area_wtd"      "CAT_BEDPERM_5_area_wtd"      "CAT_BEDPERM_6_area_wtd"      "CAT_BEDPERM_7_area_wtd"     
[71] "TOT_BEDPERM_1"               "TOT_BEDPERM_2"               "TOT_BEDPERM_3"               "TOT_BEDPERM_4"               "TOT_BEDPERM_5"              
[76] "TOT_BEDPERM_6"               "TOT_BEDPERM_7"               "CAT_STRM_DENS_area_wtd"      "CAT_BASIN_SLOPE_area_wtd"    "CAT_STREAM_SLOPE_length_wtd"
[81] "TOT_BASIN_SLOPE"             "TOT_STREAM_SLOPE"            "TOT_STRM_DENS"               "CAT_FRESHWATER_WD_area_wtd"  "TOT_FRESHWATER_WD"          
[86] "hk_0"                        "q_local"                     "q_std"                       "q_std_per"                   "q_all"                      
[91] "Per_Local"                   "nDown"                      
>
```

@janetrbarclay, the code here generates the same .feather file that you've been working from (on caldera). So as long as that format works within your workflow and plays nicely with river-dl, I don't think this PR needs further review. 

closes #21 