### PR TITLE
track subset_nc_to_comid.py

### DIFF
--- a/2a_process_nhd_downscaling.R
+++ b/2a_process_nhd_downscaling.R
@@ -94,6 +94,15 @@ p2a_targets_list <- list(
       select(seg_id_nat, date, seginc_potet)
   ),
   
+  # Track the .py script as a file target so that downstream targets rebuild
+  # if the .py script is edited. We do this because targets does not seem to 
+  # automatically detect changes in functions within .py scripts.
+  tar_target(
+    p2a_py_file,
+    "2a_process_nhd_downscaling/src/subset_nc_to_comid.py",
+    format = "file"
+  ),
+  
   # Subset the DRB meteorological data to only include the NHDPlusv2 catchments 
   # (COMID) that intersect the NHM segments. `subset_nc_to_comid()` originally
   # developed by Jeff Sadler as part of the PGDL-DO project:
@@ -102,7 +111,7 @@ p2a_targets_list <- list(
   tar_target(
     p2a_met_data_nhd_mainstem_reaches,
     {
-      reticulate::source_python("2a_process_nhd_downscaling/src/subset_nc_to_comid.py")
+      reticulate::source_python(p2a_py_file)
       subset_nc_to_comids(p1_drb_nhd_gridmet, 
                           p2a_dendritic_nhd_reaches_along_NHM_w_cats$comid) %>%
         as_tibble() %>%


### PR DESCRIPTION
To build the NHD gridmet target (`p2a_met_data_nhd_mainstem_reaches`) we use a python function called `subset_nc_to_comid`. I realized that if `subset_nc_to_comid.py` is edited, downstream targets are not automatically flagged as outdated (though we want those targets to be rebuilt if we edit the .py script). 

This PR adds a new "file" target to track the .py script (`p2a_py_file`). The NHD gridmet target (`p2a_met_data_nhd_mainstem_reaches`) now depends on `p2a_py_file`, and so any edits to the .py script will cause the gridmet target to become outdated and rebuilt. 

I don't think you need to run the pipeline for this review - if you do, note that the NHD gridmet target takes awhile to run (e.g. ~2 hours). 

Closes #55 