### PR TITLE
Add documentation

### DIFF
--- a/2b_process_nhm_groundwater.R
+++ b/2b_process_nhm_groundwater.R
@@ -190,7 +190,11 @@ p2b_targets_list <- list(
                 .groups = "drop")
   ),
   
-  # Combine NHM-scale river and catchment attributes into a single data frame
+  # Combine NHM-scale river and catchment attributes into a single data frame.
+  # Note that the resulting data frame for the DRB consists of 456 target
+  # reaches. In Barclay et al. (In Prep, 2023) seg_id_nat 3558 is omitted from 
+  # the network due to odd PRMS-SNTemp values and so Barclay et al. (In Prep, 2023)
+  # predicts temperature on 455 reaches in the DRB. 
   tar_target(
     p2b_static_inputs_nhm_combined,
     p2b_static_inputs_nhm_formatted %>%


### PR DESCRIPTION
This is a small PR that adds one comment to the `2b_process_nhm_groundwater.R` file. I ultimately opted not to omit the reach that is excluded from Janet's paper, but to avoid confusion in a few months when I may have forgotten 😅 I wanted to at least make a note that we know the number of reaches in the output data is different from what is used in Janet's paper.

Closes #61