### PR TITLE
Remove 3 cols for final target `p2b_static_inputs_nhm_combined`

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -447,7 +447,8 @@ p1_targets_list <- list(
   ),
   tar_target(
     p1_modflow_discharge,
-    arrow::read_feather(p1_modflow_discharge_feather)
+    arrow::read_feather(p1_modflow_discharge_feather) |> 
+      select(!c(q_std,q_std_per,nDown))
   )
   
 )


### PR DESCRIPTION
Removing three cols identified as no longer required for final nhm attributes feather file. 
